### PR TITLE
Ensure dependecies for ring, memberlist are respected

### DIFF
--- a/pkg/fire/fire.go
+++ b/pkg/fire/fire.go
@@ -131,11 +131,12 @@ func (f *Fire) setupModuleManager() error {
 
 	// Add dependencies
 	deps := map[string][]string{
-		All:         {Agent, Ingester, Distributor},
-		Distributor: {Ring, Server},
-		Agent:       {Server},
-		Ingester:    {Server, MemberlistKV},
-		Ring:        {MemberlistKV},
+		All:          {Agent, Ingester, Distributor},
+		Distributor:  {Ring, Server},
+		Agent:        {Server},
+		Ingester:     {Server, MemberlistKV},
+		Ring:         {Server, MemberlistKV},
+		MemberlistKV: {Server},
 
 		// Store:                    {Overrides, IndexGatewayRing},
 		// Querier:                  {Store, Ring, Server, IngesterQuerier, TenantConfigs, UsageReport},


### PR DESCRIPTION
This avoids panic at start-up
