### PR TITLE
Only run go test on Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ 1.18.2 ]
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go


### PR DESCRIPTION
There has been some problems running mac os tests, that originate from
arctic db. Disable for now, as they are not of much use at present.
