### PR TITLE
Improve error message from scraper

### DIFF
--- a/pkg/agent/target.go
+++ b/pkg/agent/target.go
@@ -230,13 +230,16 @@ func (t *Target) fetchProfile(ctx context.Context, profileType string, buf io.Wr
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("server returned HTTP status %s", resp.Status)
-	}
-
 	b, err := ioutil.ReadAll(io.TeeReader(resp.Body, buf))
 	if err != nil {
 		return fmt.Errorf("failed to read body: %w", err)
+	}
+
+	if resp.StatusCode/100 != 2 {
+		if len(b) > 0 {
+			return fmt.Errorf("server returned HTTP status (%d) %v", resp.StatusCode, string(bytes.TrimSpace(b)))
+		}
+		return fmt.Errorf("server returned HTTP status (%d) %v", resp.StatusCode, resp.Status)
 	}
 
 	if len(b) == 0 {


### PR DESCRIPTION
This also includes the response body of the non 2xx response, so it is clearer what is wrong with the scrape.

Before:

```
$ curl -s localhost:4100/targets | jq '.activeTargets[] | select(.lastError!="") | .lastError' | sort -u
"server returned HTTP status 500 Internal Server Error"
```

After:

```
$ curl -s localhost:4100/targets | jq '.activeTargets[] | select(.lastError!="") | .lastError' | sort -u
"server returned HTTP status (500) Could not enable CPU profiling: cpu profiling already in use"
```