### PR TITLE
Intern pprof labels and avoid allocations.

### DIFF
--- a/pkg/firedb/profile_labels.go
+++ b/pkg/firedb/profile_labels.go
@@ -1,0 +1,61 @@
+package firedb
+
+import (
+	"sync"
+
+	profilev1 "github.com/grafana/fire/pkg/gen/google/v1"
+)
+
+type labelCache struct {
+	labels map[labelKey]*profilev1.Label
+	rw     sync.RWMutex
+}
+
+func (lc *labelCache) init() {
+	lc.labels = make(map[labelKey]*profilev1.Label)
+}
+
+func (lc *labelCache) rewriteLabels(t stringConversionTable, in []*profilev1.Label) []*profilev1.Label {
+	lc.rw.RLock()
+	defer lc.rw.RUnlock()
+	for i, l := range in {
+		k := labelKey{
+			Key:     t[l.Key],
+			NumUnit: t[l.NumUnit],
+			Str:     t[l.Str],
+			Num:     l.Num,
+		}
+		l, ok := lc.labels[k]
+		if ok {
+			in[i] = l
+			continue
+		}
+		lc.rw.RUnlock()
+		lc.rw.Lock()
+		l, ok = lc.labels[k]
+		if !ok {
+			l = &profilev1.Label{
+				Key:     k.Key,
+				NumUnit: k.NumUnit,
+				Str:     k.Str,
+				Num:     k.Num,
+			}
+			lc.labels[k] = l
+			in[i] = l
+			lc.rw.Unlock()
+			lc.rw.RLock()
+			continue
+		}
+		lc.rw.Unlock()
+		lc.rw.RLock()
+		in[i] = l
+	}
+	return in
+}
+
+type labelKey struct {
+	Key     int64
+	Str     int64
+	Num     int64
+	NumUnit int64
+}


### PR DESCRIPTION
```
❯ benchstat before.txt after.txt
name                   old time/op    new time/op    delta
HeadIngestProfiles-16    10.1ms ± 9%     9.9ms ± 2%     ~     (p=0.165 n=10+10)

name                   old alloc/op   new alloc/op   delta
HeadIngestProfiles-16    7.50MB ± 0%    7.00MB ± 0%   -6.62%  (p=0.000 n=9+10)

name                   old allocs/op  new allocs/op  delta
HeadIngestProfiles-16     63.5k ± 0%     52.3k ± 0%  -17.76%  (p=0.000 n=9+10)
```

I expect this to fix https://github.com/grafana/fire/issues/70