### PR TITLE
Add size metric for head types

### DIFF
--- a/pkg/firedb/functions.go
+++ b/pkg/firedb/functions.go
@@ -1,6 +1,8 @@
 package firedb
 
 import (
+	"unsafe"
+
 	profilev1 "github.com/grafana/fire/pkg/gen/google/v1"
 )
 
@@ -11,8 +13,9 @@ type functionsKey struct {
 	StartLine  int64
 }
 
-type functionsHelper struct {
-}
+type functionsHelper struct{}
+
+const functionSize = uint64(unsafe.Sizeof(profilev1.Function{}))
 
 func (*functionsHelper) key(f *profilev1.Function) functionsKey {
 	return functionsKey{
@@ -38,4 +41,7 @@ func (*functionsHelper) setID(_, newID uint64, f *profilev1.Function) uint64 {
 	var oldID = f.Id
 	f.Id = newID
 	return oldID
+}
+func (*functionsHelper) size(_ *profilev1.Function) uint64 {
+	return functionSize
 }

--- a/pkg/firedb/locations.go
+++ b/pkg/firedb/locations.go
@@ -2,6 +2,7 @@ package firedb
 
 import (
 	"encoding/binary"
+	"unsafe"
 
 	"github.com/cespare/xxhash/v2"
 
@@ -13,6 +14,11 @@ type locationsKey struct {
 	Address   uint64
 	LinesHash uint64
 }
+
+const (
+	lineSize     = uint64(unsafe.Sizeof(profilev1.Line{}))
+	locationSize = uint64(unsafe.Sizeof(profilev1.Location{}))
+)
 
 type locationsHelper struct{}
 
@@ -59,4 +65,8 @@ func (*locationsHelper) setID(_, newID uint64, l *profilev1.Location) uint64 {
 	oldID := l.Id
 	l.Id = newID
 	return oldID
+}
+
+func (*locationsHelper) size(l *profilev1.Location) uint64 {
+	return uint64(len(l.Line))*lineSize + locationSize
 }

--- a/pkg/firedb/mappings.go
+++ b/pkg/firedb/mappings.go
@@ -1,10 +1,14 @@
 package firedb
 
 import (
+	"unsafe"
+
 	profilev1 "github.com/grafana/fire/pkg/gen/google/v1"
 )
 
 type mappingsHelper struct{}
+
+const mappingSize = uint64(unsafe.Sizeof(profilev1.Mapping{}))
 
 type mappingsKey struct {
 	MemoryStart     uint64
@@ -46,4 +50,8 @@ func (*mappingsHelper) setID(_, newID uint64, m *profilev1.Mapping) uint64 {
 	var oldID = m.Id
 	m.Id = newID
 	return oldID
+}
+
+func (*mappingsHelper) size(_ *profilev1.Mapping) uint64 {
+	return mappingSize
 }

--- a/pkg/firedb/stacktraces.go
+++ b/pkg/firedb/stacktraces.go
@@ -2,10 +2,15 @@ package firedb
 
 import (
 	"encoding/binary"
+	"unsafe"
 
 	"github.com/cespare/xxhash/v2"
 
 	schemav1 "github.com/grafana/fire/pkg/firedb/schemas/v1"
+)
+
+const (
+	stacktraceSize = uint64(unsafe.Sizeof(schemav1.Stacktrace{}))
 )
 
 type stacktracesKey uint64
@@ -42,4 +47,8 @@ func (*stacktracesHelper) rewrite(r *rewriter, s *schemav1.Stacktrace) error {
 
 func (*stacktracesHelper) setID(oldID, newID uint64, s *schemav1.Stacktrace) uint64 {
 	return oldID
+}
+
+func (*stacktracesHelper) size(s *schemav1.Stacktrace) uint64 {
+	return stacktraceSize + uint64(len(s.LocationIDs)*8)
 }

--- a/pkg/firedb/strings.go
+++ b/pkg/firedb/strings.go
@@ -25,6 +25,10 @@ func (*stringsHelper) rewrite(*rewriter, string) error {
 	return nil
 }
 
+func (*stringsHelper) size(s string) uint64 {
+	return uint64(len(s))
+}
+
 func (*stringsHelper) setID(oldID, newID uint64, s string) uint64 {
 	return oldID
 }


### PR DESCRIPTION
Keeps head metrics per type

Example: 

```
# HELP fire_head_profiles_created_total Total number of profiles created in the head
# TYPE fire_head_profiles_created_total counter
fire_head_profiles_created_total 83
# HELP fire_head_size_bytes Size of a particular in memory store within the head firedb block.
# TYPE fire_head_size_bytes gauge
fire_head_size_bytes{type="functions"} 45200
fire_head_size_bytes{type="mappings"} 672
fire_head_size_bytes{type="pprof-labels"} 4176
fire_head_size_bytes{type="profiles"} 236856
fire_head_size_bytes{type="stacktraces"} 41544
fire_head_size_bytes{type="strings"} 42688
```

Fixes #71 