### PR TITLE
Use parquet list schema for stacktraces

### DIFF
--- a/pkg/firedb/schemas/v1/stacktraces.go
+++ b/pkg/firedb/schemas/v1/stacktraces.go
@@ -9,17 +9,17 @@ import (
 var (
 	stacktracesSchema = parquet.NewSchema("Stacktrace", fireparquet.Group{
 		fireparquet.NewGroupField("ID", parquet.Encoded(parquet.Uint(64), &parquet.DeltaBinaryPacked)),
-		fireparquet.NewGroupField("LocationIDs", parquet.Repeated(parquet.Uint(64))),
+		fireparquet.NewGroupField("LocationIDs", parquet.List(parquet.Uint(64))),
 	})
 )
 
 type Stacktrace struct {
-	LocationIDs []uint64 `parquet:","`
+	LocationIDs []uint64 `parquet:",list"`
 }
 
 type storedStacktrace struct {
 	ID          uint64   `parquet:",delta"`
-	LocationIDs []uint64 `parquet:","`
+	LocationIDs []uint64 `parquet:",list"`
 }
 
 type StacktracePersister struct{}


### PR DESCRIPTION
This is a cosmetic change. (Even before things were store, but not displayed correctly using thrid party tooling).

This is how it looks like now:
```
$ pqrs cat data/head/01G7XRZFHP796NF04E7XX7SDMM/stacktraces.parquet | head -n 5

##############################################################
File: data/head/01G7XRZFHP796NF04E7XX7SDMM/stacktraces.parquet
##############################################################

{ID: 0, LocationIDs: [0, 1, 2, 3, 4, 5, 6, 7, 2, 8, 2, 9, 2, 10, 2, 11, 12, 2, 13, 14]}
{ID: 1, LocationIDs: [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35]}
{ID: 2, LocationIDs: [36, 37, 38, 39, 40, 41]}
{ID: 3, LocationIDs: [42, 40, 41]}
{ID: 4, LocationIDs: [43, 44, 45, 46, 47, 48, 49, 23, 24, 25, 26, 27, 28, 29, 30, 31, 50, 51, 34, 35]}
```
