### PR TITLE
Ensure we skip empty value stacktraces sample when querying

### DIFF
--- a/pkg/firedb/head.go
+++ b/pkg/firedb/head.go
@@ -394,6 +394,9 @@ func (h *Head) SelectProfiles(ctx context.Context, req *connect.Request[ingestv1
 			Stacktraces: make([]*ingestv1.StacktraceSample, 0, len(profile.Samples)),
 		}
 		for _, s := range profile.Samples {
+			if s.Values[idx] == 0 {
+				continue
+			}
 			locs := h.stacktraces.slice[s.StacktraceID].LocationIDs
 			fnIds := make([]int32, 0, len(locs))
 			for _, loc := range locs {
@@ -414,7 +417,9 @@ func (h *Head) SelectProfiles(ctx context.Context, req *connect.Request[ingestv1
 				FunctionIds: fnIds,
 			})
 		}
-		result = append(result, p)
+		if len(p.Stacktraces) > 0 {
+			result = append(result, p)
+		}
 		return nil
 	})
 	sort.Slice(result, func(i, j int) bool {

--- a/pkg/firedb/head_test.go
+++ b/pkg/firedb/head_test.go
@@ -94,6 +94,16 @@ func newProfileFoo() *profilev1.Profile {
 	}
 }
 
+func newEmptyProfile() *profilev1.Profile {
+	p := newProfileBar()
+	for _, s := range p.Sample {
+		for i := range s.Value {
+			s.Value[i] = 0
+		}
+	}
+	return p
+}
+
 func newProfileBar() *profilev1.Profile {
 	baseTable := append([]string{""}, valueTypeStrings...)
 	baseTableLen := int64(len(baseTable)) + 0
@@ -272,11 +282,15 @@ func TestSelectProfiles(t *testing.T) {
 	for i := int64(0); i < 4; i++ {
 		pF := newProfileFoo()
 		pB := newProfileBar()
+		pE := newEmptyProfile()
 		pF.TimeNanos = int64(time.Second * time.Duration(i))
+		pE.TimeNanos = int64(time.Second * time.Duration(i))
 		pB.TimeNanos = int64(time.Second * time.Duration(i))
 		err = head.Ingest(context.Background(), pF, uuid.New(), &commonv1.LabelPair{Name: "job", Value: "foo"}, &commonv1.LabelPair{Name: "__name__", Value: "foomemory"})
 		require.NoError(t, err)
 		err = head.Ingest(context.Background(), pB, uuid.New(), &commonv1.LabelPair{Name: "job", Value: "bar"}, &commonv1.LabelPair{Name: "__name__", Value: "memory"})
+		require.NoError(t, err)
+		err = head.Ingest(context.Background(), pE, uuid.New(), &commonv1.LabelPair{Name: "job", Value: "bar"}, &commonv1.LabelPair{Name: "__name__", Value: "memory"})
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
While we won't send empty values anymore from the distributor when all values are zero, because we pack multiple profile together we can still have stack-traces that have zero values ( for instance alloc_count is not empty but in_memory is in that case the distributor won't remove the sample.)