### PR TITLE
Fix string slice length bug

### DIFF
--- a/pkg/firedb/strings.go
+++ b/pkg/firedb/strings.go
@@ -15,7 +15,14 @@ func (*stringsHelper) key(s string) string {
 }
 
 func (*stringsHelper) addToRewriter(r *rewriter, m idConversionTable) {
-	r.strings = make(stringConversionTable, len(m))
+	var maxID int64
+	for id := range m {
+		if id > maxID {
+			maxID = id
+		}
+	}
+	r.strings = make(stringConversionTable, maxID+1)
+
 	for x, y := range m {
 		r.strings[x] = y
 	}


### PR DESCRIPTION
This ensures that the string conversion map has the right length. This bug was introduced a7e0f43e30209cca694f0ae4d70922e3433a0579.

This change allocates  the correct size of an array to match the highest
key id in the string rewrite map.
