### PR TITLE
Do not match labels on name label

### DIFF
--- a/deploy/helm/fire/templates/deployments-statefulsets.yaml
+++ b/deploy/helm/fire/templates/deployments-statefulsets.yaml
@@ -20,7 +20,6 @@ spec:
     matchLabels:
       {{- include "fire.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: {{ $component | quote }}
-      name: {{ if eq $component "all" }}"fire"{{ else }}"{{ $component }}"{{ end }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Name label is only a requirement for Grafana Labs internal metric scraping.
