### PR TITLE
Order stacktraces by ID to have a deterministic flamegraph

### DIFF
--- a/pkg/querier/profile.go
+++ b/pkg/querier/profile.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/samber/lo"
 
 	ingestv1 "github.com/grafana/fire/pkg/gen/ingester/v1"
 	"github.com/grafana/fire/pkg/model"
@@ -142,10 +143,7 @@ func mergeStacktraces(profiles []profileWithSymbols) []stacktraces {
 			stacktrace.value += st.Value
 		}
 	}
-	ids := make([]uint64, 0, len(stacktracesByID))
-	for id := range stacktracesByID {
-		ids = append(ids, id)
-	}
+	ids := lo.Keys(stacktracesByID)
 	sort.Slice(ids, func(i, j int) bool {
 		return ids[i] < ids[j]
 	})


### PR DESCRIPTION
This orders the stacktraces based on the ID. This allows to output a deterministic flamegraph.

(It is worth trying to watch explore with an auto-refresh, then you can see the individual parts of it growing)

I don't think this should be optional. I have not checked it's impact, but that's probably the best position to order, as we already have the stacktrace ID.

Fixes #111 