### PR TITLE
Sort profiles by SeriesRefs

### DIFF
--- a/pkg/firedb/schemas/v1/profiles.go
+++ b/pkg/firedb/schemas/v1/profiles.go
@@ -83,8 +83,8 @@ func (*ProfilePersister) Schema() *parquet.Schema {
 
 func (*ProfilePersister) SortingColumns() SortingColumns {
 	return parquet.SortingColumns(
-		parquet.Ascending("TimeNanos"),
 		parquet.Ascending("SeriesRefs"),
+		parquet.Ascending("TimeNanos"),
 		parquet.Ascending("ID"),
 	)
 }


### PR DESCRIPTION
This sorts the rows first by the SeriesRefs and then by the TimeNano.

I think that's benecifical over sorting it by TimeNano first and then
SeriesRefs, as the TimeNano can be quite easily found within a RowGroup
as the Min,Max allows to select relevant rows.
