### PR TITLE
Fixes parquet schema sorting for list

### DIFF
--- a/pkg/firedb/schemas/v1/profiles.go
+++ b/pkg/firedb/schemas/v1/profiles.go
@@ -83,7 +83,7 @@ func (*ProfilePersister) Schema() *parquet.Schema {
 
 func (*ProfilePersister) SortingColumns() SortingColumns {
 	return parquet.SortingColumns(
-		parquet.Ascending("SeriesRefs"),
+		parquet.Ascending("SeriesRefs", "list", "element"),
 		parquet.Ascending("TimeNanos"),
 		parquet.Ascending("ID"),
 	)

--- a/pkg/firedb/schemas/v1/stacktraces.go
+++ b/pkg/firedb/schemas/v1/stacktraces.go
@@ -6,12 +6,10 @@ import (
 	fireparquet "github.com/grafana/fire/pkg/parquet"
 )
 
-var (
-	stacktracesSchema = parquet.NewSchema("Stacktrace", fireparquet.Group{
-		fireparquet.NewGroupField("ID", parquet.Encoded(parquet.Uint(64), &parquet.DeltaBinaryPacked)),
-		fireparquet.NewGroupField("LocationIDs", parquet.List(parquet.Uint(64))),
-	})
-)
+var stacktracesSchema = parquet.NewSchema("Stacktrace", fireparquet.Group{
+	fireparquet.NewGroupField("ID", parquet.Encoded(parquet.Uint(64), &parquet.DeltaBinaryPacked)),
+	fireparquet.NewGroupField("LocationIDs", parquet.List(parquet.Uint(64))),
+})
 
 type Stacktrace struct {
 	LocationIDs []uint64 `parquet:",list"`
@@ -35,7 +33,7 @@ func (*StacktracePersister) Schema() *parquet.Schema {
 func (*StacktracePersister) SortingColumns() SortingColumns {
 	return parquet.SortingColumns(
 		parquet.Ascending("ID"),
-		parquet.Ascending("LocationIDs"),
+		parquet.Ascending("LocationIDs", "list", "element"),
 	)
 }
 


### PR DESCRIPTION
Following parquet code it seems that for list you need to select the element. as in `ListName.List.Element`