### PR TITLE
Ship blocks to object storage

### DIFF
--- a/cmd/firetool/blocks.go
+++ b/cmd/firetool/blocks.go
@@ -4,44 +4,71 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"github.com/go-kit/log/level"
 	"github.com/olekukonko/tablewriter"
 	"github.com/thanos-io/objstore/providers/filesystem"
 
 	"github.com/grafana/fire/pkg/firedb"
+	"github.com/grafana/fire/pkg/firedb/block"
 )
 
-func tableInfo(info firedb.TableInfo) string {
-	return fmt.Sprintf("%d (%s in %d RGs)", info.Rows, humanize.Bytes(info.Bytes), info.RowGroups)
+func fileInfo(f *block.File) string {
+	if f != nil && f.Parquet != nil {
+		return fmt.Sprintf("%d (%s in %d RGs)", f.Parquet.NumRows, humanize.Bytes(f.SizeBytes), f.Parquet.NumRowGroups)
+	}
+	if f != nil && f.TSDB != nil {
+		return fmt.Sprintf("%d series", f.TSDB.NumSeries)
+	}
+	return ""
 }
 
-func blocksList(_ context.Context) error {
+func blocksList(ctx context.Context) error {
 	bucket, err := filesystem.NewBucket(cfg.blocks.path)
 	if err != nil {
 		return err
 	}
 
-	q := firedb.NewBlockQuerier(logger, bucket)
-	if err := q.Open(); err != nil {
+	metas, err := firedb.NewBlockQuerier(logger, bucket).BlockMetas(ctx)
+	if err != nil {
 		return err
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Block ID", "MinTime", "MaxTime", "Duration", "Profiles", "Stacktraces", "Locations", "Functions", "Strings"})
-	for _, blockInfo := range q.BlockInfo() {
+	table.SetHeader([]string{"Block ID", "MinTime", "MaxTime", "Duration", "Index", "Profiles", "Stacktraces", "Locations", "Functions", "Strings"})
+	for _, blockInfo := range metas {
 		table.Append([]string{
-			blockInfo.ID.String(),
+			blockInfo.ULID.String(),
 			blockInfo.MinTime.Time().Format(time.RFC3339),
 			blockInfo.MaxTime.Time().Format(time.RFC3339),
 			blockInfo.MaxTime.Time().Sub(blockInfo.MinTime.Time()).String(),
-			tableInfo(blockInfo.Profiles),
-			tableInfo(blockInfo.Stacktraces),
-			tableInfo(blockInfo.Locations),
-			tableInfo(blockInfo.Functions),
-			tableInfo(blockInfo.Strings),
+			fileInfo(blockInfo.FileByRelPath("index.tsdb")),
+			fileInfo(blockInfo.FileByRelPath("profiles.parquet")),
+			fileInfo(blockInfo.FileByRelPath("stacktraces.parquet")),
+			fileInfo(blockInfo.FileByRelPath("locations.parquet")),
+			fileInfo(blockInfo.FileByRelPath("functions.parquet")),
+			fileInfo(blockInfo.FileByRelPath("strings.parquet")),
 		})
+
+		if cfg.blocks.restoreMissingMeta {
+			blockPath := filepath.Join(cfg.blocks.path, blockInfo.ULID.String())
+			blockMetaPath := filepath.Join(blockPath, block.MetaFilename)
+
+			if _, err := os.Stat(blockMetaPath); err == nil {
+				continue
+			} else if !os.IsNotExist(err) {
+				level.Error(logger).Log("msg", "unable to check for existing "+block.MetaFilename+" file", "path", blockMetaPath, "err", err)
+				continue
+			}
+
+			if _, err := blockInfo.WriteToFile(logger, blockPath); err != nil {
+				level.Error(logger).Log("msg", "unable to write regenerated "+block.MetaFilename, "path", blockMetaPath, "err", err)
+				continue
+			}
+		}
 	}
 	table.Render()
 

--- a/cmd/firetool/main.go
+++ b/cmd/firetool/main.go
@@ -15,7 +15,8 @@ import (
 var cfg struct {
 	verbose bool
 	blocks  struct {
-		path string
+		path               string
+		restoreMissingMeta bool
 	}
 }
 
@@ -32,9 +33,10 @@ func main() {
 	app.Flag("verbose", "Enable verbose logging.").Short('v').Default("0").BoolVar(&cfg.verbose)
 
 	blocksCmd := app.Command("blocks", "Operate on Grafana Fire's blocks.")
-	blocksCmd.Flag("path", "Path to blocks directory").Default("./data/head").StringVar(&cfg.blocks.path)
+	blocksCmd.Flag("path", "Path to blocks directory").Default("./data/local").StringVar(&cfg.blocks.path)
 
 	blocksListCmd := blocksCmd.Command("list", "List blocks.")
+	blocksListCmd.Flag("restore-missing-meta", "").Default("false").BoolVar(&cfg.blocks.restoreMissingMeta)
 
 	parsedCmd := kingpin.MustParse(app.Parse(os.Args[1:]))
 

--- a/pkg/fire/modules.go
+++ b/pkg/fire/modules.go
@@ -13,9 +13,11 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	grpcgw "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/pkg/errors"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/version"
+	objstoreclient "github.com/thanos-io/objstore/client"
 	"github.com/thanos-io/thanos/pkg/discovery/dns"
 	"github.com/weaveworks/common/server"
 	"github.com/weaveworks/common/user"
@@ -48,6 +50,7 @@ const (
 	Querier      string = "querier"
 	GRPCGateway  string = "grpc-gateway"
 	FireDB       string = "firedb"
+	Storage      string = "storage"
 
 	// RuntimeConfig            string = "runtime-config"
 	// Overrides                string = "overrides"
@@ -163,11 +166,29 @@ func (f *Fire) initFireDB() (_ services.Service, err error) {
 
 	return f.fireDB, nil
 }
+func (f *Fire) initStorage() (_ services.Service, err error) {
+
+	if cfg := f.Cfg.Storage.BucketConfig; len(cfg) > 0 {
+		b, err := objstoreclient.NewBucket(
+			f.logger,
+			[]byte(cfg),
+			f.reg,
+			"storage",
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to initialise bucket")
+		}
+		f.storageBucket = b
+	}
+
+	return nil, nil
+
+}
 
 func (f *Fire) initIngester() (_ services.Service, err error) {
 	f.Cfg.Ingester.LifecyclerConfig.ListenPort = f.Cfg.Server.HTTPListenPort
 
-	ingester, err := ingester.New(f.Cfg.Ingester, f.logger, f.reg, f.fireDB)
+	ingester, err := ingester.New(f.Cfg.Ingester, f.logger, f.reg, f.fireDB, f.storageBucket)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/firedb/block/block.go
+++ b/pkg/firedb/block/block.go
@@ -1,0 +1,200 @@
+package block
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/runutil"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/thanos-io/objstore"
+)
+
+const (
+	IndexFilename        = "index.tsdb"
+	ParquetSuffix        = ".parquet"
+	DeletionMarkFilename = "deletion-mark.json"
+
+	HostnameLabel = "__hostname__"
+)
+
+// DownloadMeta downloads only meta file from bucket by block ID.
+// TODO(bwplotka): Differentiate between network error & partial upload.
+func DownloadMeta(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid.ULID) (Meta, error) {
+	rc, err := bkt.Get(ctx, path.Join(id.String(), MetaFilename))
+	if err != nil {
+		return Meta{}, errors.Wrapf(err, "meta.json bkt get for %s", id.String())
+	}
+	defer runutil.CloseWithLogOnErr(logger, rc, "download meta bucket client")
+
+	var m Meta
+
+	obj, err := io.ReadAll(rc)
+	if err != nil {
+		return Meta{}, errors.Wrapf(err, "read meta.json for block %s", id.String())
+	}
+
+	if err = json.Unmarshal(obj, &m); err != nil {
+		return Meta{}, errors.Wrapf(err, "unmarshal meta.json for block %s", id.String())
+	}
+
+	return m, nil
+}
+
+func IsBlockDir(path string) (id ulid.ULID, ok bool) {
+	id, err := ulid.Parse(filepath.Base(path))
+	return id, err == nil
+}
+
+// upload uploads block from given block dir that ends with block id.
+// It makes sure cleanup is done on error to avoid partial block uploads.
+// TODO(bplotka): Ensure bucket operations have reasonable backoff retries.
+// NOTE: Upload updates `meta.Thanos.File` section.
+func upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir string) error {
+	df, err := os.Stat(bdir)
+	if err != nil {
+		return err
+	}
+	if !df.IsDir() {
+		return errors.Errorf("%s is not a directory", bdir)
+	}
+
+	// Verify dir.
+	id, err := ulid.Parse(df.Name())
+	if err != nil {
+		return errors.Wrap(err, "not a block dir")
+	}
+
+	meta, err := ReadFromDir(bdir)
+	if err != nil {
+		// No meta or broken meta file.
+		return errors.Wrap(err, "read meta")
+	}
+
+	// ensure labels are initialized
+	if meta.Labels == nil {
+		meta.Labels = make(map[string]string)
+	}
+
+	// add hostname if available
+	if hostname, err := os.Hostname(); err == nil {
+		meta.Labels[HostnameLabel] = hostname
+	}
+
+	metaEncoded := strings.Builder{}
+	if err != nil {
+		return errors.Wrap(err, "gather meta file stats")
+	}
+
+	if _, err := meta.WriteTo(&metaEncoded); err != nil {
+		return errors.Wrap(err, "encode meta file")
+	}
+
+	// loop through files
+	for _, file := range meta.Files {
+		if err := objstore.UploadFile(ctx, logger, bkt, path.Join(bdir, file.RelPath), path.Join(id.String(), file.RelPath)); err != nil {
+			return cleanUp(logger, bkt, id, errors.Wrapf(err, "uploading file '%s'", file.RelPath))
+		}
+	}
+
+	// Meta.json always need to be uploaded as a last item. This will allow to assume block directories without meta file to be pending uploads.
+	if err := bkt.Upload(ctx, path.Join(id.String(), MetaFilename), strings.NewReader(metaEncoded.String())); err != nil {
+		// Don't call cleanUp here. Despite getting error, meta.json may have been uploaded in certain cases,
+		// and even though cleanUp will not see it yet, meta.json may appear in the bucket later.
+		// (Eg. S3 is known to behave this way when it returns 503 "SlowDown" error).
+		// If meta.json is not uploaded, this will produce partial blocks, but such blocks will be cleaned later.
+		return errors.Wrap(err, "upload meta file")
+	}
+
+	return nil
+}
+
+// Upload uploads a TSDB block to the object storage. It verifies basic
+// features of Thanos block.
+func Upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir string) error {
+	return upload(ctx, logger, bkt, bdir)
+}
+
+func cleanUp(logger log.Logger, bkt objstore.Bucket, id ulid.ULID, err error) error {
+	// Cleanup the dir with an uncancelable context.
+	cleanErr := Delete(context.Background(), logger, bkt, id)
+	if cleanErr != nil {
+		return errors.Wrapf(err, "failed to clean block after upload issue. Partial block in system. Err: %s", err.Error())
+	}
+	return err
+}
+
+// Delete removes directory that is meant to be block directory.
+// NOTE: Always prefer this method for deleting blocks.
+//  * We have to delete block's files in the certain order (meta.json first and deletion-mark.json last)
+//  to ensure we don't end up with malformed partial blocks. Thanos system handles well partial blocks
+//  only if they don't have meta.json. If meta.json is present Thanos assumes valid block.
+//  * This avoids deleting empty dir (whole bucket) by mistake.
+func Delete(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid.ULID) error {
+	metaFile := path.Join(id.String(), MetaFilename)
+	deletionMarkFile := path.Join(id.String(), DeletionMarkFilename)
+
+	// Delete block meta file.
+	ok, err := bkt.Exists(ctx, metaFile)
+	if err != nil {
+		return errors.Wrapf(err, "stat %s", metaFile)
+	}
+
+	if ok {
+		if err := bkt.Delete(ctx, metaFile); err != nil {
+			return errors.Wrapf(err, "delete %s", metaFile)
+		}
+		level.Debug(logger).Log("msg", "deleted file", "file", metaFile, "bucket", bkt.Name())
+	}
+
+	// Delete the block objects, but skip:
+	// - The metaFile as we just deleted. This is required for eventual object storages (list after write).
+	// - The deletionMarkFile as we'll delete it at last.
+	err = deleteDirRec(ctx, logger, bkt, id.String(), func(name string) bool {
+		return name == metaFile || name == deletionMarkFile
+	})
+	if err != nil {
+		return err
+	}
+
+	// Delete block deletion mark.
+	ok, err = bkt.Exists(ctx, deletionMarkFile)
+	if err != nil {
+		return errors.Wrapf(err, "stat %s", deletionMarkFile)
+	}
+
+	if ok {
+		if err := bkt.Delete(ctx, deletionMarkFile); err != nil {
+			return errors.Wrapf(err, "delete %s", deletionMarkFile)
+		}
+		level.Debug(logger).Log("msg", "deleted file", "file", deletionMarkFile, "bucket", bkt.Name())
+	}
+
+	return nil
+}
+
+// deleteDirRec removes all objects prefixed with dir from the bucket. It skips objects that return true for the passed keep function.
+// NOTE: For objects removal use `block.Delete` strictly.
+func deleteDirRec(ctx context.Context, logger log.Logger, bkt objstore.Bucket, dir string, keep func(name string) bool) error {
+	return bkt.Iter(ctx, dir, func(name string) error {
+		// If we hit a directory, call DeleteDir recursively.
+		if strings.HasSuffix(name, objstore.DirDelim) {
+			return deleteDirRec(ctx, logger, bkt, name, keep)
+		}
+		if keep(name) {
+			return nil
+		}
+		if err := bkt.Delete(ctx, name); err != nil {
+			return err
+		}
+		level.Debug(logger).Log("msg", "deleted file", "file", name, "bucket", bkt.Name())
+		return nil
+	})
+}

--- a/pkg/firedb/block/metadata.go
+++ b/pkg/firedb/block/metadata.go
@@ -1,0 +1,268 @@
+package block
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/multierror"
+	"github.com/grafana/dskit/runutil"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+)
+
+const (
+	UnknownSource   SourceType = ""
+	IngesterSource  SourceType = "ingester"
+	CompactorSource SourceType = "compactor"
+)
+
+const (
+	MetaFilename = "meta.json"
+)
+
+type SourceType string
+
+type MetaVersion int
+
+const (
+	// Version1 is a enumeration of Fire section of TSDB meta supported by Fire.
+	MetaVersion1 = MetaVersion(1)
+)
+
+type BlockStats struct {
+	NumSamples  uint64 `json:"numSamples,omitempty"`
+	NumSeries   uint64 `json:"numSeries,omitempty"`
+	NumProfiles uint64 `json:"numProfiles,omitempty"`
+}
+
+type File struct {
+	RelPath string `json:"relPath"`
+	// SizeBytes is optional (e.g meta.json does not show size).
+	SizeBytes uint64 `json:"sizeBytes,omitempty"`
+
+	// Parquet can contain some optional Parquet file info
+	Parquet *ParquetFile `json:"parquet,omitempty"`
+	// TSDB can contain some optional TSDB file info
+	TSDB *TSDBFile `json:"tsdb,omitempty"`
+}
+
+type ParquetFile struct {
+	NumRowGroups uint64 `json:"numRowGroups,omitempty"`
+	NumRows      uint64 `json:"numRows,omitempty"`
+}
+
+type TSDBFile struct {
+	NumSeries uint64 `json:"numSeries,omitempty"`
+}
+
+type Meta struct {
+	// Unique identifier for the block and its contents. Changes on compaction.
+	ULID ulid.ULID `json:"ulid"`
+
+	// MinTime and MaxTime specify the time range all samples
+	// in the block are in.
+	MinTime model.Time `json:"minTime"`
+	MaxTime model.Time `json:"maxTime"`
+
+	// Stats about the contents of the block.
+	Stats BlockStats `json:"stats,omitempty"`
+
+	// File is a sorted (by rel path) list of all files in block directory of this block known to FireDB.
+	// Sorted by relative path.
+	Files []File `json:"files,omitempty"`
+
+	// Information on compactions the block was created from.
+	Compaction tsdb.BlockMetaCompaction `json:"compaction"`
+
+	// Version of the index format.
+	Version MetaVersion `json:"version"`
+
+	// Labels are the external labels identifying the producer as well as tenant.
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Source is a real upload source of the block.
+	Source SourceType `json:"source,omitempty"`
+}
+
+func (m *Meta) FileByRelPath(name string) *File {
+	for _, f := range m.Files {
+		if f.RelPath == name {
+			return &f
+		}
+	}
+	return nil
+}
+
+func (m *Meta) InRange(start, end model.Time) bool {
+	return InRange(m.MinTime, m.MaxTime, start, end)
+}
+
+func (m *Meta) String() string {
+	return fmt.Sprintf(
+		"%s (min time: %s, max time: %s)",
+		m.ULID,
+		m.MinTime.Time().Format(time.RFC3339Nano),
+		m.MaxTime.Time().Format(time.RFC3339Nano),
+	)
+}
+
+var ulidEntropy = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func generateULID() ulid.ULID {
+	return ulid.MustNew(ulid.Timestamp(time.Now()), ulidEntropy)
+}
+
+func NewMeta() *Meta {
+	return &Meta{
+		ULID: generateULID(),
+
+		MinTime: math.MaxInt64,
+		MaxTime: 0,
+		Labels:  make(map[string]string),
+	}
+}
+
+func MetaFromDir(dir string) (*Meta, int64, error) {
+	b, err := os.ReadFile(filepath.Join(dir, MetaFilename))
+	if err != nil {
+		return nil, 0, err
+	}
+	var m Meta
+
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, 0, err
+	}
+	if m.Version != MetaVersion1 {
+		return nil, 0, errors.Errorf("unexpected meta file version %d", m.Version)
+	}
+
+	return &m, int64(len(b)), nil
+}
+
+type wrappedWriter struct {
+	w io.Writer
+	n int
+}
+
+func (w *wrappedWriter) Write(p []byte) (n int, err error) {
+	n, err = w.w.Write(p)
+	if err != nil {
+		return 0, err
+	}
+	w.n += n
+	return n, nil
+}
+
+func (meta *Meta) WriteTo(w io.Writer) (int64, error) {
+	wrapped := &wrappedWriter{
+		w: w,
+	}
+	enc := json.NewEncoder(wrapped)
+	enc.SetIndent("", "\t")
+	return int64(wrapped.n), enc.Encode(meta)
+}
+
+func (meta *Meta) WriteToFile(logger log.Logger, dir string) (int64, error) {
+	meta.Version = MetaVersion1
+
+	// Make any changes to the file appear atomic.
+	path := filepath.Join(dir, MetaFilename)
+	tmp := path + ".tmp"
+	defer func() {
+		if err := os.RemoveAll(tmp); err != nil {
+			level.Error(logger).Log("msg", "remove tmp file", "err", err.Error())
+		}
+	}()
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		return 0, err
+	}
+
+	jsonMeta, err := json.MarshalIndent(meta, "", "\t")
+	if err != nil {
+		return 0, err
+	}
+
+	n, err := f.Write(jsonMeta)
+	if err != nil {
+		return 0, multierror.New(err, f.Close()).Err()
+	}
+
+	// Force the kernel to persist the file on disk to avoid data loss if the host crashes.
+	if err := f.Sync(); err != nil {
+		return 0, multierror.New(err, f.Close()).Err()
+	}
+	if err := f.Close(); err != nil {
+		return 0, err
+	}
+	return int64(n), fileutil.Replace(tmp, path)
+}
+
+func (meta *Meta) TSDBBlockMeta() tsdb.BlockMeta {
+	return tsdb.BlockMeta{
+		ULID:    meta.ULID,
+		MinTime: int64(meta.MinTime),
+		MaxTime: int64(meta.MaxTime),
+	}
+}
+
+// ReadFromDir reads the given meta from <dir>/meta.json.
+func ReadFromDir(dir string) (*Meta, error) {
+	f, err := os.Open(filepath.Join(dir, filepath.Clean(MetaFilename)))
+	if err != nil {
+		return nil, err
+	}
+	return Read(f)
+}
+
+func exhaustCloseWithErrCapture(err *error, r io.ReadCloser, format string) {
+	_, copyErr := io.Copy(ioutil.Discard, r)
+
+	runutil.CloseWithErrCapture(err, r, format)
+
+	// Prepend the io.Copy error.
+	merr := multierror.MultiError{}
+	merr.Add(copyErr)
+	merr.Add(*err)
+
+	*err = merr.Err()
+}
+
+// Read the block meta from the given reader.
+func Read(rc io.ReadCloser) (_ *Meta, err error) {
+	defer exhaustCloseWithErrCapture(&err, rc, "close meta JSON")
+
+	var m Meta
+	if err = json.NewDecoder(rc).Decode(&m); err != nil {
+		return nil, err
+	}
+
+	if m.Version != MetaVersion1 {
+		return nil, errors.Errorf("unexpected meta file version %d", m.Version)
+	}
+
+	return &m, nil
+}
+
+func InRange(min, max, start, end model.Time) bool {
+	if start > max {
+		return false
+	}
+	if end < min {
+		return false
+	}
+	return true
+}

--- a/pkg/firedb/block_querier_test.go
+++ b/pkg/firedb/block_querier_test.go
@@ -47,14 +47,14 @@ func Test_BlockQuerier(t *testing.T) {
 	// no flush the head to disk
 	require.NoError(t, head.Flush(ctx))
 
-	blockPath := filepath.Join(tsdbPath, "head")
+	blockPath := filepath.Join(tsdbPath, pathLocal)
 
 	b, err := filesystem.NewBucket(blockPath)
 	require.NoError(t, err)
 
 	// open resulting block
 	q := NewBlockQuerier(log.NewNopLogger(), b)
-	require.NoError(t, q.Open())
+	require.NoError(t, q.Sync(context.Background()))
 
 	result, err := q.SelectProfiles(ctx, connect.NewRequest(&ingestv1.SelectProfilesRequest{
 		LabelSelector: `{test="label"}`,

--- a/pkg/firedb/deduplicating_slice.go
+++ b/pkg/firedb/deduplicating_slice.go
@@ -11,6 +11,7 @@ import (
 	"github.com/segmentio/parquet-go"
 	"go.uber.org/atomic"
 
+	"github.com/grafana/fire/pkg/firedb/block"
 	schemav1 "github.com/grafana/fire/pkg/firedb/schemas/v1"
 )
 
@@ -45,7 +46,7 @@ func (s *deduplicatingSlice[M, K, H, P]) Size() uint64 {
 }
 
 func (s *deduplicatingSlice[M, K, H, P]) Init(path string) error {
-	file, err := os.OpenFile(filepath.Join(path, s.persister.Name()+".parquet"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o644)
+	file, err := os.OpenFile(filepath.Join(path, s.persister.Name()+block.ParquetSuffix), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
 		return err
 	}
@@ -73,7 +74,7 @@ func (s *deduplicatingSlice[M, K, H, P]) Close() error {
 
 const maxRowGroupSize = 1000
 
-func (s *deduplicatingSlice[M, K, H, P]) Flush() (int, error) {
+func (s *deduplicatingSlice[M, K, H, P]) Flush() (numRows uint64, numRowGroups uint64, err error) {
 	// intialise buffer if not existing
 	if s.buffer == nil {
 		s.buffer = parquet.NewBuffer(s.persister.Schema(), s.persister.SortingColumns())
@@ -88,7 +89,7 @@ func (s *deduplicatingSlice[M, K, H, P]) Flush() (int, error) {
 
 	if rowsToFlush == 0 {
 		s.lock.RUnlock()
-		return 0, nil
+		return 0, 0, nil
 	}
 
 	var rows = make([]parquet.Row, rowsToFlush)
@@ -101,27 +102,26 @@ func (s *deduplicatingSlice[M, K, H, P]) Flush() (int, error) {
 
 	if _, err := s.buffer.WriteRows(rows); err != nil {
 		s.lock.RUnlock()
-		return 0, err
+		return 0, 0, err
 	}
 	s.lock.RUnlock()
 
 	sort.Sort(s.buffer)
 
-	_, err := s.writer.WriteRowGroup(s.buffer)
-	if err != nil {
-		return 0, err
+	if _, err := s.writer.WriteRowGroup(s.buffer); err != nil {
+		return 0, 0, err
 	}
 
 	s.buffer.Reset()
 	s.rowsFlushed += rowsToFlush
 
 	// call myself recursively
-	rowsFlushed, err := s.Flush()
+	rowsFlushed, rowGroupsFlushed, err := s.Flush()
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
-	return rowsFlushed + rowsToFlush, nil
+	return rowsFlushed + uint64(rowsToFlush), rowGroupsFlushed + 1, nil
 }
 
 func (s *deduplicatingSlice[M, K, H, P]) ingest(ctx context.Context, elems []M, rewriter *rewriter) error {

--- a/pkg/firedb/shipper/shipper.go
+++ b/pkg/firedb/shipper/shipper.go
@@ -1,0 +1,407 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+// Package shipper detects directories on the local file system and uploads
+// them to a block storage.
+
+// TODO: Fix attribution
+
+package shipper
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"math"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/runutil"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/fire/pkg/firedb/block"
+)
+
+type metrics struct {
+	dirSyncs          prometheus.Counter
+	dirSyncFailures   prometheus.Counter
+	uploads           prometheus.Counter
+	uploadFailures    prometheus.Counter
+	uploadedCompacted prometheus.Gauge
+}
+
+func newMetrics(reg prometheus.Registerer, uploadCompacted bool) *metrics {
+	var m metrics
+
+	m.dirSyncs = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "fire_shipper_dir_syncs_total",
+		Help: "Total number of dir syncs",
+	})
+	m.dirSyncFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "fire_shipper_dir_sync_failures_total",
+		Help: "Total number of failed dir syncs",
+	})
+	m.uploads = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "fire_shipper_uploads_total",
+		Help: "Total number of uploaded blocks",
+	})
+	m.uploadFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "fire_shipper_upload_failures_total",
+		Help: "Total number of block upload failures",
+	})
+	uploadCompactedGaugeOpts := prometheus.GaugeOpts{
+		Name: "fire_shipper_upload_compacted_done",
+		Help: "If 1 it means shipper uploaded all compacted blocks from the filesystem.",
+	}
+	if uploadCompacted {
+		m.uploadedCompacted = promauto.With(reg).NewGauge(uploadCompactedGaugeOpts)
+	} else {
+		m.uploadedCompacted = promauto.With(nil).NewGauge(uploadCompactedGaugeOpts)
+	}
+	return &m
+}
+
+// Shipper watches a directory for matching files and directories and uploads
+// them to a remote data store.
+type Shipper struct {
+	logger      log.Logger
+	metrics     *metrics
+	bucket      objstore.Bucket
+	blockLister BlockLister
+	source      block.SourceType
+
+	uploadCompacted        bool
+	allowOutOfOrderUploads bool
+}
+
+// New creates a new shipper that detects new TSDB blocks in dir and uploads them to
+// remote if necessary. It attaches the Thanos metadata section in each meta JSON file.
+// If uploadCompacted is enabled, it also uploads compacted blocks which are already in filesystem.
+func New(
+	logger log.Logger,
+	r prometheus.Registerer,
+	blockLister BlockLister,
+	bucket objstore.Bucket,
+	source block.SourceType,
+	uploadCompacted bool,
+	allowOutOfOrderUploads bool,
+) *Shipper {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+
+	return &Shipper{
+		logger:                 logger,
+		blockLister:            blockLister,
+		bucket:                 bucket,
+		metrics:                newMetrics(r, uploadCompacted),
+		source:                 source,
+		allowOutOfOrderUploads: allowOutOfOrderUploads,
+		uploadCompacted:        uploadCompacted,
+	}
+}
+
+type BlockLister interface {
+	LocalDataPath() string
+	BlockMetas(ctx context.Context) ([]*block.Meta, error)
+}
+
+// Timestamps returns the minimum timestamp for which data is available and the highest timestamp
+// of blocks that were successfully uploaded.
+func (s *Shipper) Timestamps() (minTime, maxSyncTime model.Time, err error) {
+	ctx := context.Background()
+	meta, err := ReadMetaFile(s.blockLister.LocalDataPath())
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "read shipper meta file")
+	}
+	// Build a map of blocks we already uploaded.
+	hasUploaded := make(map[ulid.ULID]struct{}, len(meta.Uploaded))
+	for _, id := range meta.Uploaded {
+		hasUploaded[id] = struct{}{}
+	}
+
+	minTime = model.Time(math.MaxInt64)
+	maxSyncTime = model.Time(math.MinInt64)
+
+	metas, err := s.blockLister.BlockMetas(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, m := range metas {
+		if m.MinTime < minTime {
+			minTime = m.MinTime
+		}
+		if _, ok := hasUploaded[m.ULID]; ok && m.MaxTime > maxSyncTime {
+			maxSyncTime = m.MaxTime
+		}
+	}
+
+	if minTime == math.MaxInt64 {
+		// No block yet found. We cannot assume any min block size so propagate 0 minTime.
+		minTime = 0
+	}
+	return minTime, maxSyncTime, nil
+}
+
+type lazyOverlapChecker struct {
+	synced bool
+	logger log.Logger
+	bucket objstore.Bucket
+
+	metas       []tsdb.BlockMeta
+	lookupMetas map[ulid.ULID]struct{}
+}
+
+func newLazyOverlapChecker(logger log.Logger, bucket objstore.Bucket) *lazyOverlapChecker {
+	return &lazyOverlapChecker{
+		logger: logger,
+		bucket: bucket,
+
+		lookupMetas: map[ulid.ULID]struct{}{},
+	}
+}
+
+func (c *lazyOverlapChecker) sync(ctx context.Context) error {
+	if err := c.bucket.Iter(ctx, "", func(path string) error {
+		id, ok := block.IsBlockDir(path)
+		if !ok {
+			return nil
+		}
+
+		m, err := block.DownloadMeta(ctx, c.logger, c.bucket, id)
+		if err != nil {
+			return err
+		}
+
+		c.metas = append(c.metas, m.TSDBBlockMeta())
+		c.lookupMetas[m.ULID] = struct{}{}
+		return nil
+
+	}); err != nil {
+		return errors.Wrap(err, "get all block meta.")
+	}
+
+	c.synced = true
+	return nil
+}
+
+func (c *lazyOverlapChecker) IsOverlapping(ctx context.Context, newMeta tsdb.BlockMeta) error {
+	if !c.synced {
+		level.Info(c.logger).Log("msg", "gathering all existing blocks from the remote bucket for check", "id", newMeta.ULID.String())
+		if err := c.sync(ctx); err != nil {
+			return err
+		}
+	}
+
+	// TODO(bwplotka) so confusing! we need to sort it first. Add comment to TSDB code.
+	metas := append([]tsdb.BlockMeta{newMeta}, c.metas...)
+	sort.Slice(metas, func(i, j int) bool {
+		return metas[i].MinTime < metas[j].MinTime
+	})
+	if o := tsdb.OverlappingBlocks(metas); len(o) > 0 {
+		// TODO(bwplotka): Consider checking if overlaps relates to block in concern?
+		return errors.Errorf("shipping compacted block %s is blocked; overlap spotted: %s", newMeta.ULID, o.String())
+	}
+	return nil
+}
+
+// Sync performs a single synchronization, which ensures all non-compacted local blocks have been uploaded
+// to the object bucket once.
+//
+// If uploaded.
+//
+// It is not concurrency-safe, however it is compactor-safe (running concurrently with compactor is ok).
+func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
+	meta, err := ReadMetaFile(s.blockLister.LocalDataPath())
+	if err != nil {
+		// If we encounter any error, proceed with an empty meta file and overwrite it later.
+		// The meta file is only used to avoid unnecessary bucket.Exists call,
+		// which are properly handled by the system if their occur anyway.
+		if !os.IsNotExist(err) {
+			level.Warn(s.logger).Log("msg", "reading meta file failed, will override it", "err", err)
+		}
+		meta = &Meta{Version: MetaVersion1}
+	}
+
+	// Build a map of blocks we already uploaded.
+	hasUploaded := make(map[ulid.ULID]struct{}, len(meta.Uploaded))
+	for _, id := range meta.Uploaded {
+		hasUploaded[id] = struct{}{}
+	}
+
+	// Reset the uploaded slice so we can rebuild it only with blocks that still exist locally.
+	meta.Uploaded = nil
+
+	var (
+		checker    = newLazyOverlapChecker(s.logger, s.bucket)
+		uploadErrs int
+	)
+
+	metas, err := s.blockLister.BlockMetas(ctx)
+	if err != nil {
+		return 0, err
+	}
+	for _, m := range metas {
+		// Do not sync a block if we already uploaded or ignored it. If it's no longer found in the bucket,
+		// it was generally removed by the compaction process.
+		if _, uploaded := hasUploaded[m.ULID]; uploaded {
+			meta.Uploaded = append(meta.Uploaded, m.ULID)
+			continue
+		}
+
+		// We only ship of the first compacted block level as normal flow.
+		if m.Compaction.Level > 1 {
+			if !s.uploadCompacted {
+				continue
+			}
+		}
+
+		// Check against bucket if the meta file for this block exists.
+		ok, err := s.bucket.Exists(ctx, path.Join(m.ULID.String(), block.MetaFilename))
+		if err != nil {
+			return 0, errors.Wrap(err, "check exists")
+		}
+		if ok {
+			meta.Uploaded = append(meta.Uploaded, m.ULID)
+			continue
+		}
+
+		// Skip overlap check if out of order uploads is enabled.
+		if m.Compaction.Level > 1 && !s.allowOutOfOrderUploads {
+			if err := checker.IsOverlapping(ctx, m.TSDBBlockMeta()); err != nil {
+				return 0, errors.Errorf("Found overlap or error during sync, cannot upload compacted block, details: %v", err)
+			}
+		}
+
+		if err := s.upload(ctx, m); err != nil {
+			if !s.allowOutOfOrderUploads {
+				return 0, errors.Wrapf(err, "upload %v", m.ULID)
+			}
+
+			// No error returned, just log line. This is because we want other blocks to be uploaded even
+			// though this one failed. It will be retried on second Sync iteration.
+			level.Error(s.logger).Log("msg", "shipping failed", "block", m.ULID, "err", err)
+			uploadErrs++
+			continue
+		}
+		meta.Uploaded = append(meta.Uploaded, m.ULID)
+		uploaded++
+		s.metrics.uploads.Inc()
+	}
+	if err := WriteMetaFile(s.logger, s.blockLister.LocalDataPath(), meta); err != nil {
+		level.Warn(s.logger).Log("msg", "updating meta file failed", "err", err)
+	}
+
+	s.metrics.dirSyncs.Inc()
+	if uploadErrs > 0 {
+		s.metrics.uploadFailures.Add(float64(uploadErrs))
+		return uploaded, errors.Errorf("failed to sync %v blocks", uploadErrs)
+	}
+
+	if s.uploadCompacted {
+		s.metrics.uploadedCompacted.Set(1)
+	}
+	return uploaded, nil
+}
+
+// sync uploads the block if not exists in remote storage.
+// TODO(khyatisoneji): Double check if block does not have deletion-mark.json for some reason, otherwise log it or return error.
+func (s *Shipper) upload(ctx context.Context, meta *block.Meta) error {
+	level.Info(s.logger).Log("msg", "upload new block", "id", meta.ULID)
+
+	updir := filepath.Join(s.blockLister.LocalDataPath(), meta.ULID.String())
+
+	meta.Source = s.source
+	if _, err := meta.WriteToFile(s.logger, updir); err != nil {
+		return errors.Wrap(err, "write meta file")
+	}
+	return block.Upload(ctx, s.logger, s.bucket, updir)
+}
+
+// Meta defines the format thanos.shipper.json file that the shipper places in the data directory.
+type Meta struct {
+	Version  int         `json:"version"`
+	Uploaded []ulid.ULID `json:"uploaded"`
+}
+
+const (
+	// MetaFilename is the known JSON filename for meta information.
+	MetaFilename = "shipper.json"
+
+	// MetaVersion1 represents 1 version of meta.
+	MetaVersion1 = 1
+)
+
+// WriteMetaFile writes the given meta into <dir>/thanos.shipper.json.
+func WriteMetaFile(logger log.Logger, dir string, meta *Meta) error {
+	// Make any changes to the file appear atomic.
+	path := filepath.Join(dir, MetaFilename)
+	tmp := path + ".tmp"
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "\t")
+
+	if err := enc.Encode(meta); err != nil {
+		runutil.CloseWithLogOnErr(logger, f, "write meta file close")
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return renameFile(logger, tmp, path)
+}
+
+// ReadMetaFile reads the given meta from <dir>/shipper.json.
+func ReadMetaFile(dir string) (*Meta, error) {
+	b, err := ioutil.ReadFile(filepath.Join(dir, filepath.Clean(MetaFilename)))
+	if err != nil {
+		return nil, err
+	}
+	var m Meta
+
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	if m.Version != MetaVersion1 {
+		return nil, errors.Errorf("unexpected meta file version %d", m.Version)
+	}
+
+	return &m, nil
+}
+
+func renameFile(logger log.Logger, from, to string) error {
+	if err := os.RemoveAll(to); err != nil {
+		return err
+	}
+	if err := os.Rename(from, to); err != nil {
+		return err
+	}
+
+	// Directory was renamed; sync parent dir to persist rename.
+	pdir, err := fileutil.OpenDir(filepath.Dir(to))
+	if err != nil {
+		return err
+	}
+
+	if err = fileutil.Fdatasync(pdir); err != nil {
+		runutil.CloseWithLogOnErr(logger, pdir, "rename file dir close")
+		return err
+	}
+	return pdir.Close()
+}

--- a/pkg/firedb/tsdb/index/index.go
+++ b/pkg/firedb/tsdb/index/index.go
@@ -36,6 +36,7 @@ import (
 	tsdb_enc "github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 
+	"github.com/grafana/fire/pkg/firedb/block"
 	"github.com/grafana/fire/pkg/firedb/tsdb/encoding"
 	commonv1 "github.com/grafana/fire/pkg/gen/common/v1"
 	firemodel "github.com/grafana/fire/pkg/model"
@@ -1336,6 +1337,14 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 // Version returns the file format version of the underlying index.
 func (r *Reader) Version() int {
 	return r.version
+}
+
+// FileInfo returns some general stats about the underlying file
+func (r *Reader) FileInfo() block.File {
+	return block.File{
+		RelPath:   block.IndexFilename,
+		SizeBytes: uint64(r.Size()),
+	}
 }
 
 // Range marks a byte range.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"sync"
+	"time"
 
 	"github.com/bufbuild/connect-go"
 	"github.com/go-kit/log"
@@ -17,9 +19,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/fire/pkg/firedb"
+	"github.com/grafana/fire/pkg/firedb/block"
+	"github.com/grafana/fire/pkg/firedb/shipper"
 	profilev1 "github.com/grafana/fire/pkg/gen/google/v1"
 	ingesterv1 "github.com/grafana/fire/pkg/gen/ingester/v1"
 	pushv1 "github.com/grafana/fire/pkg/gen/push/v1"
+	fireobjstore "github.com/grafana/fire/pkg/objstore"
 	"github.com/grafana/fire/pkg/util"
 )
 
@@ -45,6 +50,9 @@ type Ingester struct {
 	lifecycler        *ring.Lifecycler
 	lifecyclerWatcher *services.FailureWatcher
 	fireDB            *firedb.FireDB
+
+	shipper     *shipper.Shipper
+	shipperLock sync.Mutex
 }
 
 type ingesterFlusherCompat struct {
@@ -58,11 +66,23 @@ func (i *ingesterFlusherCompat) Flush() {
 	}
 }
 
-func New(cfg Config, logger log.Logger, reg prometheus.Registerer, firedb *firedb.FireDB) (*Ingester, error) {
+func New(cfg Config, logger log.Logger, reg prometheus.Registerer, firedb *firedb.FireDB, storageBucket fireobjstore.Bucket) (*Ingester, error) {
 	i := &Ingester{
 		cfg:    cfg,
 		logger: logger,
 		fireDB: firedb,
+	}
+
+	if storageBucket != nil {
+		i.shipper = shipper.New(
+			logger,
+			reg,
+			firedb,
+			fireobjstore.BucketWithPrefix(storageBucket, "firedb"),
+			block.IngesterSource,
+			false,
+			false,
+		)
 	}
 
 	var err error
@@ -98,16 +118,41 @@ func (i *Ingester) starting(ctx context.Context) error {
 	return nil
 }
 
-func (i *Ingester) running(ctx context.Context) error {
-	var serviceError error
-	select {
-	// wait until service is asked to stop
-	case <-ctx.Done():
-	// stop
-	case err := <-i.lifecyclerWatcher.Chan():
-		serviceError = fmt.Errorf("lifecycler failed: %w", err)
+func (i *Ingester) runShipper(ctx context.Context) {
+	i.shipperLock.Lock()
+	defer i.shipperLock.Unlock()
+	if i.shipper == nil {
+		return
 	}
-	return serviceError
+	uploaded, err := i.shipper.Sync(ctx)
+	if err != nil {
+		level.Error(i.logger).Log("msg", "shipper run failed", "err", err)
+	} else {
+		level.Info(i.logger).Log("msg", "shipper finshed", "uploaded_blocks", uploaded)
+	}
+}
+
+func (i *Ingester) running(ctx context.Context) error {
+	// run shipper periodically and at start-up
+	shipperTicker := time.NewTicker(5 * time.Minute)
+	defer shipperTicker.Stop()
+	go func() {
+		i.runShipper(ctx)
+	}()
+
+	for {
+		select {
+
+		case <-ctx.Done(): // wait until service is asked to stop
+			return nil
+
+		case err := <-i.lifecyclerWatcher.Chan(): // handle lifecycler errors
+			return fmt.Errorf("lifecycler failed: %w", err)
+
+		case <-shipperTicker.C: // run shipper loop
+			i.runShipper(ctx)
+		}
+	}
 }
 
 func (i *Ingester) Push(ctx context.Context, req *connect.Request[pushv1.PushRequest]) (*connect.Response[pushv1.PushResponse], error) {


### PR DESCRIPTION
Define `meta.json` file for each block
* Upload blocks that have not been uploaded before
* Support generation of meta data from the block itself (so we can still
  use already written blocks)
* Discover new blocks periodically and notify both shipper and block
  querier
* Allow bucket configuration (just with the thanos yaml syntax
  for now)


## Example of `meta.json`

```
{
	"ulid": "01GBCSNP102TWCP4VNN6RP6RYQ",
	"minTime": 1661508182.205,
	"maxTime": 1661508186.334,
	"stats": {
		"numSamples": 728,
		"numSeries": 11,
		"numProfiles": 13
	},
	"files": [
		{
			"relPath": "functions.parquet",
			"sizeBytes": 16683,
			"parquet": {
				"numRowGroups": 1,
				"numRows": 395
			}
		},
		{
			"relPath": "index.tsdb",
			"sizeBytes": 4062,
			"tsdb": {
				"numSeries": 11
			}
		},
		{
			"relPath": "locations.parquet",
			"sizeBytes": 19561,
			"parquet": {
				"numRowGroups": 1,
				"numRows": 437
			}
		},
		{
			"relPath": "mappings.parquet",
			"sizeBytes": 1897,
			"parquet": {
				"numRowGroups": 1,
				"numRows": 7
			}
		},
		{
			"relPath": "profiles.parquet",
			"sizeBytes": 6958,
			"parquet": {
				"numRowGroups": 1,
				"numRows": 13
			}
		},
		{
			"relPath": "stacktraces.parquet",
			"sizeBytes": 22040,
			"parquet": {
				"numRowGroups": 1,
				"numRows": 193
			}
		},
		{
			"relPath": "strings.parquet",
			"sizeBytes": 37691,
			"parquet": {
				"numRowGroups": 1,
				"numRows": 601
			}
		}
	],
	"compaction": {
		"level": 0
	},
	"version": 1,
	"labels": {
		"__hostname__": "christian-x1"
	},
	"source": "ingester"
}
```

### Example of how to configure a bucket

```
server:
  http_listen_port: 4100

scrape_configs:
  - job_name: "default"
    scrape_interval: "2s"
    static_configs:
      - targets: [ '127.0.0.1:4100']

storage:
  bucketConfig: |
    type: GCS
    config:
      bucket: dev-us-central-0-profiles-dev-001-data
```