### PR TITLE
Ensure local folder is created on startup

### DIFF
--- a/pkg/firedb/firedb_test.go
+++ b/pkg/firedb/firedb_test.go
@@ -1,0 +1,25 @@
+package firedb
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateLocalDir(t *testing.T) {
+	dataPath := t.TempDir()
+	localFile := dataPath + "/local"
+	require.NoError(t, ioutil.WriteFile(localFile, []byte("d"), 0o644))
+	_, err := New(&Config{
+		DataPath: dataPath,
+	}, log.NewNopLogger(), nil)
+	require.Error(t, err)
+	require.NoError(t, os.Remove(localFile))
+	_, err = New(&Config{
+		DataPath: dataPath,
+	}, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Looks like we can fail to write the meta file at first if the folder is not created.

Adding that part on startup should resolve the log message seen:

```


2022-08-29 12:56:35 | level=warn caller=shipper.go:303 ts=2022-08-29T12:56:35.155980484Z msg="updating meta file failed" err="open data/local/shipper.json.tmp: no such file or directory"
-- | --



```