### PR TITLE
Debug backend

### DIFF
--- a/grafana/fire-datasource/.vscode/launch.json
+++ b/grafana/fire-datasource/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [{
+        "name": "Debug backend plugin",
+        "type": "go",
+        "request": "attach",
+        "mode": "remote",
+        "port": 3222,
+        "preLaunchTask": "debug",
+        "host": "127.0.0.1",
+        "showLog": true,
+        "remotePath": "${workspaceFolder}",
+        "dlvLoadConfig": {
+            "followPointers": true,
+            "maxVariableRecurse": 1,
+            "maxStringLen": 1000,
+            "maxArrayValues": 1000,
+            "maxStructFields": -1
+        }
+    }]
+}

--- a/grafana/fire-datasource/.vscode/scripts/debug-attach.sh
+++ b/grafana/fire-datasource/.vscode/scripts/debug-attach.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# so dlv and mage are in the path
+export PATH=$(go env GOPATH)/bin:$PATH
+
+PLUGIN_NAME="gpx_fire-datasource_darwin_arm64"
+PLUGIN_PID=`pgrep ${PLUGIN_NAME}`
+PORT="${2:-3222}"
+
+dlv attach ${PLUGIN_PID} --headless --listen=:${PORT} --api-version 2 --log

--- a/grafana/fire-datasource/.vscode/scripts/debug-build.sh
+++ b/grafana/fire-datasource/.vscode/scripts/debug-build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# so mage is in the path
+export PATH=$(go env GOPATH)/bin:$PATH
+
+mage -v build:debug
+mage -v reloadPlugin

--- a/grafana/fire-datasource/.vscode/tasks.json
+++ b/grafana/fire-datasource/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "build",
+        "type": "shell",
+        "command": "./.vscode/scripts/debug-build.sh",
+        "presentation": {
+          "panel": "shared"
+        }
+      },
+      {
+        "label": "debug",
+        "dependsOn": ["build"],
+        "command": "./.vscode/scripts/debug-attach.sh",
+        "isBackground": true,
+        "promptOnClose": false,
+        "presentation": {
+          "panel": "shared"
+        },
+        // this is a hack so the debugger will launch after the delve listen command
+        // VS code will give a problem warning - you can ignore it and disable the prompt
+        "problemMatcher": [
+          {
+            "pattern": [
+              {
+                "regexp": ".",
+                "file": 1,
+                "location": 2,
+                "message": 3
+              }
+            ],
+            "background": {
+              "activeOnStart": true,
+              "beginsPattern": "API",
+              "endsPattern": ".",
+            }
+          }
+        ]
+      },
+    ]
+  }
+  


### PR DESCRIPTION
This PR adds a launch config that allows us to debug and step through the datasources code. It also makes it easier to work with making backend changes and rerunning the debugger will run mage -v and mage reloadPlugin in one go so we don't have to.

<img width="1436" alt="Screenshot 2022-08-31 at 08 10 43" src="https://user-images.githubusercontent.com/90795735/187616204-8d2d45fe-ab54-4555-aca7-e6eadd94a698.png">
