### PR TITLE
Ensure Block Querier are closed

### DIFF
--- a/pkg/firedb/head.go
+++ b/pkg/firedb/head.go
@@ -517,12 +517,10 @@ func (h *Head) Series(ctx context.Context, req *connect.Request[ingestv1.SeriesR
 func (h *Head) Flush(ctx context.Context) error {
 	if len(h.profiles.slice) == 0 {
 		level.Info(h.logger).Log("msg", "head empty - no block written")
-		return nil
+		return os.RemoveAll(h.headPath)
 	}
 
-	var (
-		files = make([]block.File, len(h.tables)+1)
-	)
+	files := make([]block.File, len(h.tables)+1)
 
 	// write index
 	indexPath := filepath.Join(h.headPath, block.IndexFilename)


### PR DESCRIPTION

- First ensure we correctly close the ReaderAt from the bucket once a block is out of sync or we shutdown
- When flushing empty head, removes the folder. We have couple of empty files in dev because of this.
- And for the same reason when we stop, we avoid creating a new head which creates empty folder too.