### PR TITLE
Sort Profiles by Labels (alphabetical) in Parquet

### DIFF
--- a/cmd/parquet-tool/main.go
+++ b/cmd/parquet-tool/main.go
@@ -31,7 +31,6 @@ func main() {
 	fmt.Println("schema:", pf.Schema())
 	meta := pf.Metadata()
 	fmt.Println("Num Rows:", meta.NumRows)
-	fmt.Println("Index:", pf.ColumnIndexes())
 	for i, rg := range meta.RowGroups {
 		fmt.Println("\t Row group:", i)
 		fmt.Println("\t\t Row Count:", rg.NumRows)

--- a/pkg/firedb/schemas/v1/profiles.go
+++ b/pkg/firedb/schemas/v1/profiles.go
@@ -85,7 +85,7 @@ func (*ProfilePersister) SortingColumns() SortingColumns {
 	return parquet.SortingColumns(
 		parquet.Ascending("SeriesRefs", "list", "element"),
 		parquet.Ascending("TimeNanos"),
-		parquet.Ascending("ID"),
+		parquet.Ascending("Samples", "list", "element", "StacktraceIDs"),
 	)
 }
 

--- a/pkg/firedb/tsdb/index/chunk.go
+++ b/pkg/firedb/tsdb/index/chunk.go
@@ -15,7 +15,7 @@ type ChunkMeta struct {
 	// Bytes stored, rounded to nearest KB
 	KB uint32
 
-	Entries uint32
+	SeriesIndex uint32
 }
 
 func (c ChunkMeta) From() model.Time                 { return model.Time(c.MinTime) }
@@ -99,5 +99,4 @@ func (c ChunkMetas) Finalize() ChunkMetas {
 	// release self to pool; res will be returned instead
 	ChunkMetasPool.Put(c)
 	return res
-
 }


### PR DESCRIPTION
This allows to improve data locality by ensuring profiles from the same series are within the same page.

I'm using a hack to store the alphabetical order of a series for a given block in the ChunkMeta, but avoid for tsdb format change.

Already gives a small perf boost but I assume it will even be better once we explode profiles per series


```
go test -benchmem -run=^$  -bench ^BenchmarkDBSelectProfile$ github.com/grafana/fire/pkg/firedb -v -count=5 -timeout=0s -memprofile=mem.out -cpuprofile=cpu.out > after.txt && benchstat before.txt after.txt
name                                                   old time/op    new time/op    delta
DBSelectProfile/{}-16                                     7.23s ± 3%     7.06s ±12%     ~     (p=0.421 n=5+5)
DBSelectProfile/{}#01-16                                  4.98s ± 2%     4.73s ±24%     ~     (p=0.151 n=5+5)
DBSelectProfile/{namespace="3"}-16                        816ms ± 2%     683ms ± 3%  -16.31%  (p=0.008 n=5+5)
DBSelectProfile/{namespace="3",_pod="100"}-16            50.0ms ± 5%    45.2ms ±21%     ~     (p=0.690 n=5+5)
DBSelectProfile/{namespace="3",_pod=~".*1"}-16            180ms ± 2%     156ms ± 1%  -13.21%  (p=0.008 n=5+5)
DBSelectProfile/{namespace!="3",_pod=~".*1"}-16           726ms ± 4%     686ms ± 3%   -5.48%  (p=0.016 n=5+5)
DBSelectProfile/{namespace=~"1|4"}-16                     1.52s ± 3%     1.31s ± 2%  -13.50%  (p=0.008 n=5+5)
DBSelectProfile/{namespace=~"1|4",pod=~"1.*"}-16          901ms ± 1%     740ms ± 3%  -17.80%  (p=0.008 n=5+5)
DBSelectProfile/{namespace=~".*",_pod=~"10|20|30"}-16     173ms ± 2%     154ms ± 2%  -11.04%  (p=0.008 n=5+5)

name                                                   old alloc/op   new alloc/op   delta
DBSelectProfile/{}-16                                    6.95GB ± 0%    6.94GB ± 0%   -0.15%  (p=0.029 n=4+4)
DBSelectProfile/{}#01-16                                 3.76GB ± 0%    3.75GB ± 0%   -0.26%  (p=0.008 n=5+5)
DBSelectProfile/{namespace="3"}-16                        651MB ± 0%     646MB ± 0%   -0.73%  (p=0.008 n=5+5)
DBSelectProfile/{namespace="3",_pod="100"}-16            39.2MB ± 0%    35.9MB ± 0%   -8.38%  (p=0.008 n=5+5)
DBSelectProfile/{namespace="3",_pod=~".*1"}-16            167MB ± 0%     163MB ± 0%   -2.71%  (p=0.008 n=5+5)
DBSelectProfile/{namespace!="3",_pod=~".*1"}-16           708MB ± 0%     701MB ± 0%   -1.05%  (p=0.008 n=5+5)
DBSelectProfile/{namespace=~"1|4"}-16                    1.27GB ± 0%    1.27GB ± 0%   -0.20%  (p=0.008 n=5+5)
DBSelectProfile/{namespace=~"1|4",pod=~"1.*"}-16          743MB ± 0%     741MB ± 0%   -0.28%  (p=0.008 n=5+5)
DBSelectProfile/{namespace=~".*",_pod=~"10|20|30"}-16     180MB ± 0%     168MB ± 0%   -6.94%  (p=0.008 n=5+5)

name                                                   old allocs/op  new allocs/op  delta
DBSelectProfile/{}-16                                     17.1M ± 0%     17.1M ± 0%   -0.04%  (p=0.029 n=4+4)
DBSelectProfile/{}#01-16                                  8.77M ± 0%     8.76M ± 0%   -0.12%  (p=0.008 n=5+5)
DBSelectProfile/{namespace="3"}-16                        1.52M ± 0%     1.52M ± 0%   -0.32%  (p=0.008 n=5+5)
DBSelectProfile/{namespace="3",_pod="100"}-16             74.5k ± 0%     71.0k ± 0%   -4.61%  (p=0.008 n=5+5)
DBSelectProfile/{namespace="3",_pod=~".*1"}-16             247k ± 0%      242k ± 0%   -1.70%  (p=0.008 n=5+5)
DBSelectProfile/{namespace!="3",_pod=~".*1"}-16            970k ± 0%      963k ± 0%   -0.73%  (p=0.008 n=5+5)
DBSelectProfile/{namespace=~"1|4"}-16                     2.98M ± 0%     2.97M ± 0%   -0.15%  (p=0.008 n=5+5)
DBSelectProfile/{namespace=~"1|4",pod=~"1.*"}-16          1.70M ± 0%     1.69M ± 0%   -0.27%  (p=0.008 n=5+5)
DBSelectProfile/{namespace=~".*",_pod=~"10|20|30"}-16      241k ± 0%      234k ± 0%   -2.79%  (p=0.008 n=5+5)
```

This also adds better benchmark, btw as you can see the read path is all about allocation right now.