### PR TITLE
Datasource: Fix editor resizing

### DIFF
--- a/grafana/fire-datasource/src/QueryEditor/LabelsEditor.tsx
+++ b/grafana/fire-datasource/src/QueryEditor/LabelsEditor.tsx
@@ -25,6 +25,7 @@ export function LabelsEditor(props: Props) {
 
   return (
     <div
+      className={styles.wrapper}
       // NOTE: we will be setting inline-style-width/height on this element
       ref={containerRef}
     >
@@ -143,14 +144,17 @@ function ensureFireQL(monaco: Monaco) {
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     queryField: css`
-      border-radius: ${theme.shape.borderRadius()};
-      border: 1px solid ${theme.components.input.borderColor};
-      
       flex: 1;
       // Not exactly sure but without this the editor doe not shrink after resizing (so you can make it bigger but not
       // smaller). At the same time this does not actually make the editor 100px because it has flex 1 so I assume
       // this should sort of act as a flex-basis (but flex-basis does not work for this). So yeah CSS magic.
       width: 100px;
+    `,
+    wrapper: css`
+      display: flex;
+      flex: 1;
+      border: 1px solid rgba(36, 41, 46, 0.3);
+      border-radius: 2px;
     `,
   };
 };


### PR DESCRIPTION
Basically this fix again https://github.com/grafana/fire/pull/227 but due to this PR https://github.com/grafana/fire/pull/225 adding a separate wrapper element it needed to be adjusted and I did not notice it when merging.