### PR TITLE
Add unit tests for MergeProfilesStacktraces

### DIFF
--- a/pkg/firedb/firedb_test.go
+++ b/pkg/firedb/firedb_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -11,15 +12,19 @@ import (
 	"github.com/bufbuild/connect-go"
 	"github.com/go-kit/log"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"golang.org/x/sync/errgroup"
 
 	schemav1 "github.com/grafana/fire/pkg/firedb/schemas/v1"
 	commonv1 "github.com/grafana/fire/pkg/gen/common/v1"
 	googlev1 "github.com/grafana/fire/pkg/gen/google/v1"
 	ingestv1 "github.com/grafana/fire/pkg/gen/ingester/v1"
+	"github.com/grafana/fire/pkg/gen/ingester/v1/ingesterv1connect"
+	pushv1 "github.com/grafana/fire/pkg/gen/push/v1"
 	"github.com/grafana/fire/pkg/iter"
 	firemodel "github.com/grafana/fire/pkg/model"
 	"github.com/grafana/fire/pkg/testhelper"
@@ -169,6 +174,176 @@ func (f *fakeBidiServerMergeProfilesStacktraces) Receive() (*ingestv1.MergeProfi
 	}
 	f.keep = f.keep[1:]
 	return res, nil
+}
+
+func (f *FireDB) ingesterClient() (ingesterv1connect.IngesterServiceClient, func()) {
+	mux := http.NewServeMux()
+	mux.Handle(ingesterv1connect.NewIngesterServiceHandler(&ingesterHandlerFireDB{f}))
+	serv := testhelper.NewInMemoryServer(mux)
+
+	var httpClient *http.Client = serv.Client()
+
+	client := ingesterv1connect.NewIngesterServiceClient(
+		httpClient, serv.URL(),
+	)
+
+	return client, serv.Close
+}
+
+type ingesterHandlerFireDB struct {
+	*FireDB
+}
+
+func (i *ingesterHandlerFireDB) Push(context.Context, *connect.Request[pushv1.PushRequest]) (*connect.Response[pushv1.PushResponse], error) {
+	return nil, errors.New("not implemented")
+}
+
+func (i *ingesterHandlerFireDB) LabelValues(context.Context, *connect.Request[ingestv1.LabelValuesRequest]) (*connect.Response[ingestv1.LabelValuesResponse], error) {
+	return nil, errors.New("not implemented")
+}
+
+func (i *ingesterHandlerFireDB) LabelNames(context.Context, *connect.Request[ingestv1.LabelNamesRequest]) (*connect.Response[ingestv1.LabelNamesResponse], error) {
+	return nil, errors.New("not implemented")
+}
+
+func (i *ingesterHandlerFireDB) ProfileTypes(context.Context, *connect.Request[ingestv1.ProfileTypesRequest]) (*connect.Response[ingestv1.ProfileTypesResponse], error) {
+	return nil, errors.New("not implemented")
+}
+
+func (i *ingesterHandlerFireDB) Series(context.Context, *connect.Request[ingestv1.SeriesRequest]) (*connect.Response[ingestv1.SeriesResponse], error) {
+	return nil, errors.New("not implemented")
+}
+
+func (i *ingesterHandlerFireDB) Flush(context.Context, *connect.Request[ingestv1.FlushRequest]) (*connect.Response[ingestv1.FlushResponse], error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestMergeProfilesStacktraces(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	// ingest some sample data
+	var (
+		testDir = t.TempDir()
+		end     = time.Unix(0, int64(time.Hour))
+		start   = end.Add(-time.Minute)
+		step    = 15 * time.Second
+	)
+
+	db, err := New(&Config{
+		DataPath:      testDir,
+		BlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
+	}, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	ingestProfiles(t, db, cpuProfileGenerator, start.UnixNano(), end.UnixNano(), step,
+		&commonv1.LabelPair{Name: "namespace", Value: "my-namespace"},
+		&commonv1.LabelPair{Name: "pod", Value: "my-pod"},
+	)
+
+	// create client
+	ctx := context.Background()
+
+	client, cleanup := db.ingesterClient()
+	defer cleanup()
+
+	t.Run("request the one existing series", func(t *testing.T) {
+		bidi := client.MergeProfilesStacktraces(ctx)
+
+		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesStacktracesRequest{
+			Request: &ingestv1.SelectProfilesRequest{
+				LabelSelector: `{pod="my-pod"}`,
+				Type:          mustParseProfileSelector(t, "process_cpu:cpu:nanoseconds:cpu:nanoseconds"),
+				Start:         start.UnixMilli(),
+				End:           end.UnixMilli(),
+			},
+		}))
+
+		resp, err := bidi.Receive()
+		require.NoError(t, err)
+		require.Nil(t, resp.Result)
+		require.Len(t, resp.SelectedProfiles.LabelsSets, 1)
+		require.Len(t, resp.SelectedProfiles.Profiles, 5)
+
+		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesStacktracesRequest{
+			Profiles: []bool{true},
+		}))
+
+		// expect empty resp to signal it is finished
+		resp, err = bidi.Receive()
+		require.NoError(t, err)
+		require.Nil(t, resp.Result)
+
+		// received result
+		resp, err = bidi.Receive()
+		require.NoError(t, err)
+		require.NotNil(t, resp.Result)
+		require.Len(t, resp.Result.Stacktraces, 48)
+		require.Len(t, resp.Result.FunctionNames, 247)
+
+	})
+
+	t.Run("request non existing series", func(t *testing.T) {
+		bidi := client.MergeProfilesStacktraces(ctx)
+
+		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesStacktracesRequest{
+			Request: &ingestv1.SelectProfilesRequest{
+				LabelSelector: `{pod="not-my-pod"}`,
+				Type:          mustParseProfileSelector(t, "process_cpu:cpu:nanoseconds:cpu:nanoseconds"),
+				Start:         start.UnixMilli(),
+				End:           end.UnixMilli(),
+			},
+		}))
+
+		// expect empty resp to signal it is finished
+		resp, err := bidi.Receive()
+		require.NoError(t, err)
+		require.Nil(t, resp.Result)
+		require.Nil(t, resp.SelectedProfiles)
+
+		// still receiving a result
+		resp, err = bidi.Receive()
+		require.NoError(t, err)
+		require.NotNil(t, resp.Result)
+		require.Len(t, resp.Result.Stacktraces, 0)
+		require.Len(t, resp.Result.FunctionNames, 0)
+		require.Nil(t, resp.SelectedProfiles)
+	})
+
+	t.Run("empty request fails", func(t *testing.T) {
+		bidi := client.MergeProfilesStacktraces(ctx)
+
+		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesStacktracesRequest{}))
+
+		_, err := bidi.Receive()
+		require.EqualError(t, err, "invalid_argument: missing initial select request")
+	})
+
+	t.Run("test cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		bidi := client.MergeProfilesStacktraces(ctx)
+		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesStacktracesRequest{
+			Request: &ingestv1.SelectProfilesRequest{
+				LabelSelector: `{pod="my-pod"}`,
+				Type:          mustParseProfileSelector(t, "process_cpu:cpu:nanoseconds:cpu:nanoseconds"),
+				Start:         start.UnixMilli(),
+				End:           end.UnixMilli(),
+			},
+		}))
+		cancel()
+	})
+
+	t.Run("test close request", func(t *testing.T) {
+		bidi := client.MergeProfilesStacktraces(ctx)
+		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesStacktracesRequest{
+			Request: &ingestv1.SelectProfilesRequest{
+				LabelSelector: `{pod="my-pod"}`,
+				Type:          mustParseProfileSelector(t, "process_cpu:cpu:nanoseconds:cpu:nanoseconds"),
+				Start:         start.UnixMilli(),
+				End:           end.UnixMilli(),
+			},
+		}))
+		require.NoError(t, bidi.CloseRequest())
+	})
 }
 
 func TestFilterProfiles(t *testing.T) {

--- a/pkg/testhelper/http.go
+++ b/pkg/testhelper/http.go
@@ -1,0 +1,128 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This has been adapted from https://github.com/bufbuild/connect-go/blob/cce7065d23ae00021eb4b31284361a2d8525df21/example_init_test.go#L44-L144
+
+package testhelper
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+)
+
+// InMemoryServer is an HTTP server that uses in-memory pipes instead of TCP.
+// It supports HTTP/2 and has TLS enabled.
+//
+// The Go Playground panics if we try to start a TCP-backed server. If you're
+// not familiar with the Playground's behavior, it looks like our examples are
+// broken. This server lets us write examples that work in the playground
+// without abstracting over HTTP.
+type InMemoryServer struct {
+	server   *httptest.Server
+	listener *memoryListener
+}
+
+// NewInMemoryServer constructs and starts an inMemoryServer.
+func NewInMemoryServer(handler http.Handler) *InMemoryServer {
+	lis := &memoryListener{
+		conns:  make(chan net.Conn),
+		closed: make(chan struct{}),
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = lis
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	return &InMemoryServer{
+		server:   server,
+		listener: lis,
+	}
+}
+
+// Client returns an HTTP client configured to trust the server's TLS
+// certificate and use HTTP/2 over an in-memory pipe. Automatic HTTP-level gzip
+// compression is disabled. It closes its idle connections when the server is
+// closed.
+func (s *InMemoryServer) Client() *http.Client {
+	client := s.server.Client()
+	if transport, ok := client.Transport.(*http.Transport); ok {
+		transport.DialContext = s.listener.DialContext
+		transport.DisableCompression = true
+	}
+	return client
+}
+
+// URL is the server's URL.
+func (s *InMemoryServer) URL() string {
+	return s.server.URL
+}
+
+// Close shuts down the server, blocking until all outstanding requests have
+// completed.
+func (s *InMemoryServer) Close() {
+	s.server.Close()
+}
+
+type memoryListener struct {
+	conns  chan net.Conn
+	once   sync.Once
+	closed chan struct{}
+}
+
+// Accept implements net.Listener.
+func (l *memoryListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.conns:
+		return conn, nil
+	case <-l.closed:
+		return nil, errors.New("listener closed")
+	}
+}
+
+// Close implements net.Listener.
+func (l *memoryListener) Close() error {
+	l.once.Do(func() {
+		close(l.closed)
+	})
+	return nil
+}
+
+// Addr implements net.Listener.
+func (l *memoryListener) Addr() net.Addr {
+	return &memoryAddr{}
+}
+
+// DialContext is the type expected by http.Transport.DialContext.
+func (l *memoryListener) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	select {
+	case <-l.closed:
+		return nil, errors.New("listener closed")
+	default:
+	}
+	server, client := net.Pipe()
+	l.conns <- server
+	return client, nil
+}
+
+type memoryAddr struct{}
+
+// Network implements net.Addr.
+func (*memoryAddr) Network() string { return "memory" }
+
+// String implements io.Stringer, returning a value that matches the
+// certificates used by net/http/httptest.
+func (*memoryAddr) String() string { return "example.com" }


### PR DESCRIPTION
Meant to be merged in #226: This adds an in memory HTTP server from connect-go and uses this to test `MergeProfilesStacktraces`