### PR TITLE
Allow to override parquet configs

### DIFF
--- a/pkg/firedb/block_querier_test.go
+++ b/pkg/firedb/block_querier_test.go
@@ -13,25 +13,22 @@ import (
 	"github.com/grafana/fire/pkg/objstore/providers/filesystem"
 )
 
-func newTestHead(t testing.TB) *Head {
-	dataPath := t.TempDir()
-	head, err := NewHead(&Config{DataPath: dataPath})
-	require.NoError(t, err)
-	return head
-}
-
 func TestInMemoryReader(t *testing.T) {
 	path := t.TempDir()
 	st := deduplicatingSlice[string, string, *stringsHelper, *schemav1.StringPersister]{}
-	require.NoError(t, st.Init(path))
+	require.NoError(t, st.Init(path, &ParquetConfig{
+		MaxBufferRowCount: defaultParquetConfig.MaxBufferRowCount / 1024,
+		MaxRowGroupBytes:  defaultParquetConfig.MaxRowGroupBytes / 1024,
+		MaxBlockBytes:     defaultParquetConfig.MaxBlockBytes,
+	}))
 	rewrites := &rewriter{}
 	rgCount := 5
-	for i := 0; i < rgCount*maxBufferRowCount; i++ {
+	for i := 0; i < rgCount*st.cfg.MaxBufferRowCount; i++ {
 		require.NoError(t, st.ingest(context.Background(), []string{fmt.Sprintf("foobar %d", i)}, rewrites))
 	}
 	numRows, numRg, err := st.Flush()
 	require.NoError(t, err)
-	require.Equal(t, uint64(rgCount*maxBufferRowCount), numRows)
+	require.Equal(t, uint64(rgCount*st.cfg.MaxBufferRowCount), numRows)
 	require.Equal(t, uint64(rgCount), numRg)
 	require.NoError(t, st.Close())
 	reader := inMemoryparquetReader[*schemav1.StoredString, *schemav1.StringPersister]{}

--- a/pkg/firedb/firedb.go
+++ b/pkg/firedb/firedb.go
@@ -35,13 +35,21 @@ import (
 )
 
 type Config struct {
-	DataPath      string
-	BlockDuration time.Duration
+	DataPath         string
+	MaxBlockDuration time.Duration // Blocks are generally cut once they reach 1000M of memory size, this will setup an upper limit to the duration of data that a block has that is cut by the ingester.
+
+	Parquet *ParquetConfig `yaml:"-"` // Those configs should not be exposed to the user, rather they should be determiend by fire itself. Currently they are solely used for test cases
+}
+
+type ParquetConfig struct {
+	MaxBufferRowCount int
+	MaxRowGroupBytes  uint64 // This is the maximum row group size in bytes that the raw data uses in memory.
+	MaxBlockBytes     uint64 // This is the size of all parquet tables in memory after which a new block is cut
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.DataPath, "firedb.data-path", "./data", "Directory used for local storage.")
-	f.DurationVar(&cfg.BlockDuration, "firedb.block-duration", 30*time.Minute, "Block duration.")
+	f.DurationVar(&cfg.MaxBlockDuration, "firedb.max-block-duration", 3*time.Hour, "Upper limit to the duration of a Fire block.")
 }
 
 type FireDB struct {

--- a/pkg/firedb/firedb_test.go
+++ b/pkg/firedb/firedb_test.go
@@ -34,14 +34,14 @@ func TestCreateLocalDir(t *testing.T) {
 	localFile := dataPath + "/local"
 	require.NoError(t, ioutil.WriteFile(localFile, []byte("d"), 0o644))
 	_, err := New(&Config{
-		DataPath:      dataPath,
-		BlockDuration: 30 * time.Minute,
+		DataPath:         dataPath,
+		MaxBlockDuration: 30 * time.Minute,
 	}, log.NewNopLogger(), nil)
 	require.Error(t, err)
 	require.NoError(t, os.Remove(localFile))
 	_, err = New(&Config{
-		DataPath:      dataPath,
-		BlockDuration: 30 * time.Minute,
+		DataPath:         dataPath,
+		MaxBlockDuration: 30 * time.Minute,
 	}, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 }
@@ -134,8 +134,8 @@ func TestMergeProfilesStacktraces(t *testing.T) {
 	)
 
 	db, err := New(&Config{
-		DataPath:      testDir,
-		BlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
+		DataPath:         testDir,
+		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
 	}, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	defer require.NoError(t, db.Head().Close())

--- a/pkg/firedb/head.go
+++ b/pkg/firedb/head.go
@@ -93,7 +93,7 @@ type Helper[M Models, K comparable] interface {
 type Table interface {
 	Name() string
 	Size() uint64
-	Init(path string) error
+	Init(path string, cfg *ParquetConfig) error
 	Flush() (numRows uint64, numRowGroups uint64, err error)
 	Close() error
 }
@@ -135,6 +135,7 @@ type Head struct {
 	meta     *block.Meta
 
 	index           *profilesIndex
+	parquetConfig   *ParquetConfig
 	strings         deduplicatingSlice[string, string, *stringsHelper, *schemav1.StringPersister]
 	mappings        deduplicatingSlice[*profilev1.Mapping, mappingsKey, *mappingsHelper, *schemav1.MappingPersister]
 	functions       deduplicatingSlice[*profilev1.Function, functionsKey, *functionsHelper, *schemav1.FunctionPersister]
@@ -161,10 +162,16 @@ func NewHead(cfg *Config, opts ...HeadOption) (*Head, error) {
 		totalSamples: atomic.NewUint64(0),
 
 		flushCh:          make(chan struct{}),
-		flushForcedTimer: time.NewTimer(cfg.BlockDuration),
+		flushForcedTimer: time.NewTimer(cfg.MaxBlockDuration),
+
+		parquetConfig: defaultParquetConfig,
 	}
 	h.headPath = filepath.Join(cfg.DataPath, pathHead, h.meta.ULID.String())
 	h.localPath = filepath.Join(cfg.DataPath, pathLocal, h.meta.ULID.String())
+
+	if cfg.Parquet != nil {
+		h.parquetConfig = cfg.Parquet
+	}
 
 	// execute options
 	for _, o := range opts {
@@ -192,7 +199,7 @@ func NewHead(cfg *Config, opts ...HeadOption) (*Head, error) {
 		&h.profiles,
 	}
 	for _, t := range h.tables {
-		if err := t.Init(h.headPath); err != nil {
+		if err := t.Init(h.headPath, h.parquetConfig); err != nil {
 			return nil, err
 		}
 	}
@@ -238,10 +245,10 @@ func (h *Head) loop() {
 			close(h.flushCh)
 			return
 		case <-tick.C:
-			if currentSize := h.Size(); currentSize > maxBlockBytes {
+			if currentSize := h.Size(); currentSize > h.parquetConfig.MaxBlockBytes {
 				level.Debug(h.logger).Log(
 					"msg", "max block bytes reached, flush to disk",
-					"max_size", humanize.Bytes(maxBlockBytes),
+					"max_size", humanize.Bytes(h.parquetConfig.MaxBlockBytes),
 					"current_head_size", humanize.Bytes(currentSize),
 				)
 				close(h.flushCh)

--- a/pkg/firedb/head_test.go
+++ b/pkg/firedb/head_test.go
@@ -18,6 +18,25 @@ import (
 	firemodel "github.com/grafana/fire/pkg/model"
 )
 
+func newTestHead(t testing.TB) *testHead {
+	dataPath := t.TempDir()
+	head, err := NewHead(&Config{DataPath: dataPath})
+	require.NoError(t, err)
+	return &testHead{Head: head, t: t}
+}
+
+type testHead struct {
+	*Head
+	t testing.TB
+}
+
+func (t *testHead) Flush(ctx context.Context) error {
+	defer func() {
+		t.t.Logf("flushing head of block %v", t.Head.meta.ULID)
+	}()
+	return t.Head.Flush(ctx)
+}
+
 func parseProfile(t testing.TB, path string) *profilev1.Profile {
 	f, err := os.Open(path)
 	require.NoError(t, err, "failed opening profile: ", path)

--- a/pkg/firedb/querier_test.go
+++ b/pkg/firedb/querier_test.go
@@ -21,7 +21,7 @@ import (
 func TestQueryIndex(t *testing.T) {
 	head := newTestHead(t)
 
-	a, err := newProfileIndex(32, newHeadMetrics(prometheus.NewRegistry()).setHead(head))
+	a, err := newProfileIndex(32, newHeadMetrics(prometheus.NewRegistry()).setHead(head.Head))
 	require.NoError(t, err)
 
 	for j := 0; j < 10; j++ {

--- a/pkg/firedb/sample_merge_test.go
+++ b/pkg/firedb/sample_merge_test.go
@@ -118,8 +118,8 @@ func TestMergeSampleByStacktraces(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testPath := t.TempDir()
 			db, err := New(&Config{
-				DataPath:      testPath,
-				BlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
+				DataPath:         testPath,
+				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
 			}, log.NewNopLogger(), nil)
 			require.NoError(t, err)
 			ctx := context.Background()
@@ -261,8 +261,8 @@ func TestHeadMergeSampleByStacktraces(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testPath := t.TempDir()
 			db, err := New(&Config{
-				DataPath:      testPath,
-				BlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
+				DataPath:         testPath,
+				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
 			}, log.NewNopLogger(), nil)
 			require.NoError(t, err)
 			ctx := context.Background()
@@ -378,8 +378,8 @@ func TestMergeSampleByLabels(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testPath := t.TempDir()
 			db, err := New(&Config{
-				DataPath:      testPath,
-				BlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
+				DataPath:         testPath,
+				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
 			}, log.NewNopLogger(), nil)
 			require.NoError(t, err)
 			ctx := context.Background()
@@ -503,8 +503,8 @@ func TestHeadMergeSampleByLabels(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testPath := t.TempDir()
 			db, err := New(&Config{
-				DataPath:      testPath,
-				BlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
+				DataPath:         testPath,
+				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
 			}, log.NewNopLogger(), nil)
 			require.NoError(t, err)
 			ctx := context.Background()


### PR DESCRIPTION
This allows to override the parquet configs, to ensure we create multiple rowGroups with less profiles...