### PR TITLE
Datasource: Prevent error on empty query

### DIFF
--- a/grafana/fire-datasource/src/datasource.ts
+++ b/grafana/fire-datasource/src/datasource.ts
@@ -1,10 +1,19 @@
-import { DataSourceInstanceSettings } from '@grafana/data';
+import { DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings } from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { FireDataSourceOptions, Query, ProfileTypeMessage, SeriesMessage } from './types';
+import { Observable, of } from 'rxjs';
 
 export class FireDataSource extends DataSourceWithBackend<Query, FireDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<FireDataSourceOptions>) {
     super(instanceSettings);
+  }
+
+  query(request: DataQueryRequest<Query>): Observable<DataQueryResponse> {
+    const validTargets = request.targets.filter((t) => t.profileTypeId);
+    if (!validTargets.length) {
+      return of({ data: [] });
+    }
+    return super.query(request);
   }
 
   async getProfileTypes(): Promise<ProfileTypeMessage[]> {
@@ -17,6 +26,6 @@ export class FireDataSource extends DataSourceWithBackend<Query, FireDataSourceO
   }
 
   async getLabelNames(): Promise<string[]> {
-    return await super.getResource("labelNames");
+    return await super.getResource('labelNames');
   }
 }


### PR DESCRIPTION
Prevents this sort of error when loading the datasource in explore (as explore runs even an empty query on load and it's up to datasource to say the query isn't valid and not run it)

![Screenshot from 2022-10-03 14-35-33](https://user-images.githubusercontent.com/1014802/193578628-dfa0aa62-e5b4-4709-a613-722a6830e879.png)
