### PR TITLE
Datasource: Handle empty labels same as {}

### DIFF
--- a/grafana/fire-datasource/src/datasource.ts
+++ b/grafana/fire-datasource/src/datasource.ts
@@ -9,11 +9,25 @@ export class FireDataSource extends DataSourceWithBackend<Query, FireDataSourceO
   }
 
   query(request: DataQueryRequest<Query>): Observable<DataQueryResponse> {
-    const validTargets = request.targets.filter((t) => t.profileTypeId);
+    const validTargets = request.targets
+      .filter((t) => t.profileTypeId)
+      .map((t) => {
+        // Empty string errors out but honestly seems like we can just normalize it this way
+        if (t.labelSelector === '') {
+          return {
+            ...t,
+            labelSelector: '{}',
+          };
+        }
+        return t;
+      });
     if (!validTargets.length) {
       return of({ data: [] });
     }
-    return super.query(request);
+    return super.query({
+      ...request,
+      targets: validTargets,
+    });
   }
 
   async getProfileTypes(): Promise<ProfileTypeMessage[]> {


### PR DESCRIPTION
Before empty input errored out like this:
![Screenshot from 2022-10-04 17-26-00](https://user-images.githubusercontent.com/1014802/193860925-566e41dc-730f-4c75-b74f-4929e9150659.png)

This treats "" same as "{}"