### PR TITLE
Default to flame graph

### DIFF
--- a/grafana/phlare-datasource/src/QueryEditor/QueryEditor.tsx
+++ b/grafana/phlare-datasource/src/QueryEditor/QueryEditor.tsx
@@ -104,7 +104,7 @@ function useProfileName(profileTypes: ProfileTypeMessage[], profileTypeId: strin
   }, [profileTypeId, profileTypes]);
 }
 
-function normalizeQuery(query: Query, app?: CoreApp) {
+export function normalizeQuery(query: Query, app?: CoreApp | string) {
   let normalized = defaults(query, defaultQuery);
   if (app !== CoreApp.Explore && normalized.queryType === 'both') {
     // In dashboards and other places, we can't show both types of graphs at the same time.

--- a/grafana/phlare-datasource/src/datasource.ts
+++ b/grafana/phlare-datasource/src/datasource.ts
@@ -2,6 +2,7 @@ import { DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings } from 
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { PhlareDataSourceOptions, Query, ProfileTypeMessage, SeriesMessage } from './types';
 import { Observable, of } from 'rxjs';
+import { normalizeQuery } from './QueryEditor/QueryEditor';
 
 export class PhlareDataSource extends DataSourceWithBackend<Query, PhlareDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<PhlareDataSourceOptions>) {
@@ -19,8 +20,10 @@ export class PhlareDataSource extends DataSourceWithBackend<Query, PhlareDataSou
             labelSelector: '{}',
           };
         }
-        return t;
-      });
+
+        return normalizeQuery(t, request.app);
+      })
+
     if (!validTargets.length) {
       return of({ data: [] });
     }


### PR DESCRIPTION
Default to flame graph when going from explore to dashboard.

Fixes https://github.com/grafana/phlare/issues/200
Works with https://github.com/grafana/grafana/pull/56733

I'll move this over/double check to grafana repo when accepted.