### PR TITLE
intial docs sync

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -32,7 +32,7 @@ jobs:
       id: "publish-next"
       with:
         repository: "grafana/website"
-        branch: "phlare" # change to master after launch
+        branch: "phlare-docs" # change to master after launch
         host: "github.com"
         github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
         source_folder: "docs/sources"


### PR DESCRIPTION
Once merged, will sync to https://github.com/grafana/website/tree/phlare-docs/content/docs/phlare, and a preview will be available at https://deploy-preview-10328-zb444pucvq-vp.a.run.app/docs/phlare/next/ ( User: `grot` / Password: `YWM5YmZkM2JjMjMyMDEwMWM1ZGRmMDA` )

https://github.com/grafana/website/pull/10328 will be merged into the final PR branch for the Obscon launches.

- Needs `GH_BOT_ACCESS_TOKEN` as a secret - this will need to be added by a repo admin.
- This only adds the sync for the "next" dir, the release syncs will need to be added (after?) launch.