### PR TITLE
Avoid double collection of profiles

### DIFF
--- a/cmd/phlare/phlare.yaml
+++ b/cmd/phlare/phlare.yaml
@@ -11,3 +11,8 @@ scrape_configs:
     scrape_interval: "5s"
     static_configs:
       - targets: ["127.0.0.1:4100"]
+    # Disable CPU collection for second profile. (only one profiling request can be in flight at a time)
+    profiling_config:
+      pprof_config:
+        process_cpu:
+          enabled: false


### PR DESCRIPTION
With collection CPU profiles twice we reguarly see those errors, as a go
process can only be profiles once at a time.

> level=error caller=target.go:183 ts=2022-10-14T14:47:16.290228306Z msg="fetch profile failed" target="{__address__=\"127.0.0.1:4100\", __name__=\"process_cpu\", __profile_path__=\"/debug/pprof/profile\", __scheme__=\"http\", instance=\"127.0.0.1:4100\", job=\"foo\"}" err="server returned HTTP status (500) Could not enable CPU profiling: cpu profiling already in use"

cc @aocenas this should still allow for your use case and prevent those errors.