### PR TITLE
Use a volume to hold fire's data

### DIFF
--- a/tools/docker-compose/docker-compose.yml
+++ b/tools/docker-compose/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     command: -config.file=/etc/phlare/config.yaml
     volumes:
       - ./phlare.yaml:/etc/phlare/config.yaml
-      - ./data:/data
+      - data:/data
     networks:
       - phlare
 
@@ -24,5 +24,8 @@ services:
       - ./datasource.yaml:/etc/grafana/provisioning/datasources/datasources.yml
     networks:
       - phlare
+
+volumes:
+  data:
 
 # yaml-language-server: $schema=https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json


### PR DESCRIPTION
Without this the uid of the local data directory will be preventing
successful writes from the container, as phlare doesn't run as root
user.
