### PR TITLE
Sort stacktraces by function names

### DIFF
--- a/pkg/model/stacktraces_test.go
+++ b/pkg/model/stacktraces_test.go
@@ -93,20 +93,20 @@ func TestMergeBatchResponse(t *testing.T) {
 			expected: &ingestv1.MergeProfilesStacktracesResult{
 				Stacktraces: []*ingestv1.StacktraceSample{
 					{
-						FunctionIds: []int32{0, 1},
-						Value:       2,
-					},
-					{
-						FunctionIds: []int32{0, 1, 2},
-						Value:       6,
+						FunctionIds: []int32{4},
+						Value:       5,
 					},
 					{
 						FunctionIds: []int32{3},
 						Value:       4,
 					},
 					{
-						FunctionIds: []int32{4},
-						Value:       5,
+						FunctionIds: []int32{0, 1},
+						Value:       2,
+					},
+					{
+						FunctionIds: []int32{0, 1, 2},
+						Value:       6,
 					},
 				},
 				FunctionNames: []string{"my", "other", "stack", "foo", "bar"},


### PR DESCRIPTION
This ensures the StacktracesMerge result is always ordered consistently by taking the string order of the function names.

Unsure if we should do this here or leave to the data-source.