### PR TITLE
Java examples: reduce cpu usage.

### DIFF
--- a/tools/docker-compose/java/simple/src/main/java/Something.java
+++ b/tools/docker-compose/java/simple/src/main/java/Something.java
@@ -15,13 +15,18 @@ public class Something extends Thread {
     }
 
     private static void doSomething() {
-        int i = 0;
-        for (;;) {
-            i++;
-            if (i % 3 == 0) {
-                funcFoo();
+        try {
+            int i = 0;
+            for (;;) {
+                i++;
+                if (i % 3 == 0) {
+                    funcFoo();
+                }
+                funcBar();
+                Thread.sleep(10);
             }
-            funcBar();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 

--- a/tools/docker-compose/java/springboot/src/main/java/com/example/springboot/Something.java
+++ b/tools/docker-compose/java/springboot/src/main/java/com/example/springboot/Something.java
@@ -15,13 +15,18 @@ public class Something extends Thread {
     }
 
     private static void doSomething() {
-        int i = 0;
-        for (;;) {
-            i++;
-            if (i % 3 == 0) {
-                funcFoo();
+        try {
+            int i = 0;
+            for (;;) {
+                i++;
+                if (i % 3 == 0) {
+                    funcFoo();
+                }
+                funcBar();
+                Thread.sleep(10);
             }
-            funcBar();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
Adds a short 10ms sleep, gives cpu some breath but still shows other functions on the graph.