### PR TITLE
adds docs sync for release branches and tags

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -3,7 +3,7 @@ name: "publish-technical-documentation-release"
 on:
   push:
     branches:
-    - "v[0-9]+.[0-9]+.[0-9]+"
+    - "release/v[0-9]+.[0-9]+.[0-9]+"
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+"
     paths:
@@ -43,8 +43,8 @@ jobs:
       with:
         ref_name: "${{ github.ref_name }}"
         release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-        release_branch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-        release_branch_with_patch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+        release_branch_regexp: "^release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+        release_branch_with_patch_regexp: "^release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
 
     - name: "Determine technical documentation version"
       if: "steps.has-matching-release-tag.outputs.bool == 'true'"


### PR DESCRIPTION
This will populate `content/docs/phlare/vX.X.x` in the website repo when pushes to a release branch/tag occur. I've taken this from the Mimir repo, so please adjust to your team's branching/tagging strategy.

Once syncing I'll enable virtual latest in https://github.com/grafana/website/pull/10328.
