### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for Phlare. If this doesn't look right, choose a different [issue type](https://github.com/grafana/phlare/issues/new/choose). 
+about: Suggest an idea for Phlare.
 title: ''
 labels: ''
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/issue--bug-report.md
+++ b/.github/ISSUE_TEMPLATE/issue--bug-report.md
@@ -1,7 +1,6 @@
 ---
-name: 'Bug Report'
-about: Create a report to help us improve Phlare. If this doesn’t look right, choose a different [issue
-  type](https://github.com/grafana/phlare/issues/new/choose).
+name: Bug Report
+about: Create a report to help us improve Phlare.
 title: ''
 labels: ''
 assignees: ''


### PR DESCRIPTION
Fixed the fact that you don't have to redirect to the new issue page. Github already does it for you. 