### PR TITLE
Update grafana image references to :main

### DIFF
--- a/docs/sources/operators-guide/deploy-kubernetes/_index.md
+++ b/docs/sources/operators-guide/deploy-kubernetes/_index.md
@@ -104,14 +104,12 @@ Use a custom namespace so that you do not have to overwrite the default namespac
 
 ## Query profiles in Grafana
 
-[//TODO]:<> (Upgrade grafana image version to latest dev containing the changes)
-
 1. Install Grafana in the same Kubernetes cluster where you installed Phlare.
 
    ```
    helm upgrade -n phlare-test --install grafana grafana/grafana \
-     --set image.repository=aocenas/grafana \
-     --set image.tag=profiling-ds-2 \
+     --set image.repository=grafana/grafana \
+     --set image.tag=main \
      --set env.GF_FEATURE_TOGGLES_ENABLE=flameGraph \
      --set env.GF_AUTH_ANONYMOUS_ENABLED=true \
      --set env.GF_AUTH_ANONYMOUS_ORG_ROLE=Admin \

--- a/tools/grafana-phlare
+++ b/tools/grafana-phlare
@@ -18,15 +18,11 @@ trap 'rm -f "${datasource_provisioning}"' EXIT
 cat > "${datasource_provisioning}" <<EOF
 apiVersion: 1
 datasources:
-  - name: Phlare-Pyroscope
-    type: pyroscope-datasource
-    jsonData:
-      path: ${PYRO_URL}
   - name: Prometheus
     type: prometheus
     url: ${PROMETHEUS_URL}
   - name: Phlare
-    type: grafana-phlare-datasource
+    type: phlare
     url: ${PHLARE_URL}
     jsonData:
       httpHeaderName1: "X-Scope-OrgID"
@@ -39,8 +35,9 @@ docker run $DOCKER_ARGS --rm \
   -v "${datasource_provisioning}:/etc/grafana/provisioning/datasources/phlare.yaml:ro" \
   -v "$(pwd)"/grafana/phlare-datasource/dist:/var/lib/grafana/plugins/phlare-datasource \
   -v "$(pwd)"/grafana/flamegraph/dist:/var/lib/grafana/plugins/flamegraph \
+  -e GF_FEATURE_TOGGLES_ENABLE=flameGraph \
   -e GF_INSTALL_PLUGINS=pyroscope-datasource,pyroscope-panel \
   -e GF_DEFAULT_APP_MODE=development \
   -e GF_AUTH_ANONYMOUS_ENABLED=true \
   -e GF_AUTH_ANONYMOUS_ORG_ROLE=Admin \
-  -t -i -p 3000:3000 aocenas/grafana:explore-experiment-2
+  -t -i -p 3000:3000 grafana/grafana:main


### PR DESCRIPTION
As discussed on the sync call, we want point users to the main image, until we have a released version of Grafana.
