### PR TITLE
Ensure the doc-validator is using a particular tag

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,4 @@ test:
 
 .PHONY: validate
 validate:
-	docker run -v $(CURDIR)/sources:/docs/sources --rm grafana/doc-validator:latest /docs/sources
+	docker run -v $(CURDIR)/sources:/docs/sources --rm grafana/doc-validator:v1.5.0 /docs/sources


### PR DESCRIPTION
This will avoid breakages by more stricter versions of doc-validator.
