### PR TITLE
Stricter default for `podSecurityContext`

### DIFF
--- a/operations/phlare/helm/phlare/README.md
+++ b/operations/phlare/helm/phlare/README.md
@@ -40,6 +40,8 @@
 | phlare.podAnnotations."phlare.grafana.com/port" | string | `"4100"` |  |
 | phlare.podAnnotations."phlare.grafana.com/scrape" | string | `"true"` |  |
 | phlare.podSecurityContext.fsGroup | int | `10001` |  |
+| phlare.podSecurityContext.runAsNonRoot | bool | `true` |  |
+| phlare.podSecurityContext.runAsUser | int | `10001` |  |
 | phlare.replicaCount | int | `1` |  |
 | phlare.resources | object | `{}` |  |
 | phlare.securityContext | object | `{}` |  |

--- a/operations/phlare/helm/phlare/rendered/micro-services.yaml
+++ b/operations/phlare/helm/phlare/rendered/micro-services.yaml
@@ -698,6 +698,8 @@ spec:
       serviceAccountName: phlare-dev
       securityContext:
         fsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
       containers:
         - name: "agent"
           securityContext:
@@ -775,6 +777,8 @@ spec:
       serviceAccountName: phlare-dev
       securityContext:
         fsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
       containers:
         - name: "distributor"
           securityContext:
@@ -851,6 +855,8 @@ spec:
       serviceAccountName: phlare-dev
       securityContext:
         fsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
       containers:
         - name: "querier"
           securityContext:
@@ -1024,6 +1030,8 @@ spec:
       serviceAccountName: phlare-dev
       securityContext:
         fsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
       containers:
         - name: "ingester"
           securityContext:

--- a/operations/phlare/helm/phlare/rendered/single-binary.yaml
+++ b/operations/phlare/helm/phlare/rendered/single-binary.yaml
@@ -212,6 +212,8 @@ spec:
       serviceAccountName: phlare-dev
       securityContext:
         fsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
       containers:
         - name: "phlare"
           securityContext:

--- a/operations/phlare/helm/phlare/values.yaml
+++ b/operations/phlare/helm/phlare/values.yaml
@@ -42,6 +42,8 @@ phlare:
 
   podSecurityContext:
     fsGroup: 10001
+    runAsUser: 10001
+    runAsNonRoot: true
 
   securityContext:
     {}

--- a/operations/phlare/jsonnet/values.json
+++ b/operations/phlare/jsonnet/values.json
@@ -64,7 +64,9 @@
       "phlare.grafana.com/scrape": "true"
     },
     "podSecurityContext": {
-      "fsGroup": 10001
+      "fsGroup": 10001,
+      "runAsNonRoot": true,
+      "runAsUser": 10001
     },
     "replicaCount": 1,
     "resources": {},


### PR DESCRIPTION
Had to patch this in to conform with our own policies but seems like a good default to have