### PR TITLE
Release helm chart v0.1.2 with Phlare version v0.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run linter
         run: make lint
       - name: Check helm manifests
-        run: make helm/check
+        run: make helm/check check/unstaged-changes
 
   test-docs:
     runs-on: ubuntu-latest

--- a/operations/phlare/helm/phlare/Chart.yaml
+++ b/operations/phlare/helm/phlare/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: phlare
 description: 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 type: application
-version: 0.1.1
-appVersion: 0.1.0
+version: 0.1.2
+appVersion: 0.1.1
 dependencies:
   - name: minio
     alias: minio

--- a/operations/phlare/helm/phlare/README.md
+++ b/operations/phlare/helm/phlare/README.md
@@ -1,6 +1,6 @@
 # phlare
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
 
 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 
@@ -27,7 +27,7 @@
 | phlare.fullnameOverride | string | `""` |  |
 | phlare.image.pullPolicy | string | `"IfNotPresent"` |  |
 | phlare.image.repository | string | `"grafana/phlare"` |  |
-| phlare.image.tag | string | `"0.1.0"` |  |
+| phlare.image.tag | string | `"0.1.1"` |  |
 | phlare.imagePullSecrets | list | `[]` |  |
 | phlare.memberlist.port | int | `7946` |  |
 | phlare.memberlist.port_name | string | `"memberlist"` |  |

--- a/operations/phlare/helm/phlare/rendered/micro-services.yaml
+++ b/operations/phlare/helm/phlare/rendered/micro-services.yaml
@@ -12,10 +12,10 @@ kind: ServiceAccount
 metadata:
   name: phlare-dev
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: phlare/charts/minio/templates/secrets.yaml
@@ -358,10 +358,10 @@ kind: ConfigMap
 metadata:
   name: phlare-dev-config
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -411,10 +411,10 @@ kind: ClusterRole
 metadata:
   name: default-phlare-dev
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -437,10 +437,10 @@ kind: ClusterRoleBinding
 metadata:
   name: default-phlare-dev
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -525,10 +525,10 @@ kind: Service
 metadata:
   name: phlare-dev-memberlist
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -551,10 +551,10 @@ kind: Service
 metadata:
   name: phlare-dev-agent
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "agent"
 spec:
@@ -575,10 +575,10 @@ kind: Service
 metadata:
   name: phlare-dev-distributor
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -599,10 +599,10 @@ kind: Service
 metadata:
   name: phlare-dev-ingester
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -623,10 +623,10 @@ kind: Service
 metadata:
   name: phlare-dev-ingester-headless
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -647,10 +647,10 @@ kind: Service
 metadata:
   name: phlare-dev-querier
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -671,10 +671,10 @@ kind: Deployment
 metadata:
   name: phlare-dev-agent
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "agent"
 spec:
@@ -687,7 +687,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 710bec00736e032fa0aee126f8a107c4759d6e0e010b5e1730b18d40dbf27eb4
+        checksum/config: cc2d815c42d247cc86a1add3a57bca253ba986bd9670771845e7893bd8a81a50
         phlare.grafana.com/port: "4100"
         phlare.grafana.com/scrape: "true"
       labels:
@@ -705,7 +705,7 @@ spec:
         - name: "agent"
           securityContext:
             {}
-          image: "grafana/phlare:0.1.0"
+          image: "grafana/phlare:0.1.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=agent"
@@ -750,10 +750,10 @@ kind: Deployment
 metadata:
   name: phlare-dev-distributor
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -766,7 +766,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 710bec00736e032fa0aee126f8a107c4759d6e0e010b5e1730b18d40dbf27eb4
+        checksum/config: cc2d815c42d247cc86a1add3a57bca253ba986bd9670771845e7893bd8a81a50
         phlare.grafana.com/port: "4100"
         phlare.grafana.com/scrape: "true"
       labels:
@@ -784,7 +784,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/phlare:0.1.0"
+          image: "grafana/phlare:0.1.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -828,10 +828,10 @@ kind: Deployment
 metadata:
   name: phlare-dev-querier
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -844,7 +844,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 710bec00736e032fa0aee126f8a107c4759d6e0e010b5e1730b18d40dbf27eb4
+        checksum/config: cc2d815c42d247cc86a1add3a57bca253ba986bd9670771845e7893bd8a81a50
         phlare.grafana.com/port: "4100"
         phlare.grafana.com/scrape: "true"
       labels:
@@ -862,7 +862,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/phlare:0.1.0"
+          image: "grafana/phlare:0.1.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -1001,10 +1001,10 @@ kind: StatefulSet
 metadata:
   name: phlare-dev-ingester
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1019,7 +1019,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 710bec00736e032fa0aee126f8a107c4759d6e0e010b5e1730b18d40dbf27eb4
+        checksum/config: cc2d815c42d247cc86a1add3a57bca253ba986bd9670771845e7893bd8a81a50
         phlare.grafana.com/port: "4100"
         phlare.grafana.com/scrape: "true"
       labels:
@@ -1037,7 +1037,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/phlare:0.1.0"
+          image: "grafana/phlare:0.1.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"

--- a/operations/phlare/helm/phlare/rendered/single-binary.yaml
+++ b/operations/phlare/helm/phlare/rendered/single-binary.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: phlare-dev
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: phlare/templates/configmap.yaml
@@ -17,10 +17,10 @@ kind: ConfigMap
 metadata:
   name: phlare-dev-config
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -62,10 +62,10 @@ kind: ClusterRole
 metadata:
   name: default-phlare-dev
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -88,10 +88,10 @@ kind: ClusterRoleBinding
 metadata:
   name: default-phlare-dev
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -108,10 +108,10 @@ kind: Service
 metadata:
   name: phlare-dev-memberlist
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -134,10 +134,10 @@ kind: Service
 metadata:
   name: phlare-dev
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -158,10 +158,10 @@ kind: Service
 metadata:
   name: phlare-dev-headless
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -182,10 +182,10 @@ kind: StatefulSet
 metadata:
   name: phlare-dev
   labels:
-    helm.sh/chart: phlare-0.1.1
+    helm.sh/chart: phlare-0.1.2
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -200,7 +200,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6e8c7666812b4fd3271cfd632104da3b8b9f2c5db345c18fe122af475ea81e61
+        checksum/config: 151ca6c735203eb2f041ec5420140e6beb9b691f20daa6da728bf8e89810dca3
         phlare.grafana.com/port: "4100"
         phlare.grafana.com/scrape: "true"
       labels:
@@ -218,7 +218,7 @@ spec:
         - name: "phlare"
           securityContext:
             {}
-          image: "grafana/phlare:0.1.0"
+          image: "grafana/phlare:0.1.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"

--- a/operations/phlare/helm/phlare/values.yaml
+++ b/operations/phlare/helm/phlare/values.yaml
@@ -9,7 +9,7 @@ phlare:
     repository: grafana/phlare
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "0.1.0"
+    tag: "0.1.1"
 
   extraArgs:
     log.level: debug

--- a/operations/phlare/jsonnet/values.json
+++ b/operations/phlare/jsonnet/values.json
@@ -42,7 +42,7 @@
     "image": {
       "pullPolicy": "IfNotPresent",
       "repository": "grafana/phlare",
-      "tag": "0.1.0"
+      "tag": "0.1.1"
     },
     "imagePullSecrets": [],
     "memberlist": {


### PR DESCRIPTION
This should be merged after #450.

It releases helm chart v0.1.2 with Phlare version v0.1.1
