### PR TITLE
Add gzip accept encoding

### DIFF
--- a/pkg/agent/target.go
+++ b/pkg/agent/target.go
@@ -234,6 +234,7 @@ func (t *Target) fetchProfile(ctx context.Context, profileType string, buf io.Wr
 			return err
 		}
 		req.Header.Set("User-Agent", userAgentHeader)
+		req.Header.Set("Accept-Encoding", "gzip")
 
 		t.req = req
 	}


### PR DESCRIPTION
Since the expected profile output should be gzip:ed.

This way the handler don't have to compress the output, but can instead rely on the webserver, if the implementor wants to.

The golang pprof cli sets this header as well.