### PR TITLE
Fixes mapping slice insertion

### DIFF
--- a/pkg/phlaredb/sample_merge.go
+++ b/pkg/phlaredb/sample_merge.go
@@ -221,9 +221,9 @@ func (b *singleBlockQuerier) resolvePprofSymbols(ctx context.Context, stacktrace
 		model.A.BuildID = names[stringsIds[model.B.BuildId]]
 	}
 
-	mappingResult := make([]*profile.Mapping, len(mappingIDs))
-	for i, model := range mappingIDs {
-		mappingResult[i] = model.A
+	mappingResult := make([]*profile.Mapping, 0, len(mappingIDs))
+	for _, model := range mappingIDs {
+		mappingResult = append(mappingResult, model.A)
 	}
 
 	for id, model := range stacktraceAggrByID {


### PR DESCRIPTION
In my previous PR I didn't realize but introduce a bug that would only surface when having many mapping.

It would use the id to index the slice to create, where it should just append to the slice.

PS: Tried to create a test but that requires more refactoring so I didn't bother, but happy to try to invest more time.