### PR TITLE
[release/v0.1.0] Update publishing workflows to use organization secret (#500)

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -25,7 +25,11 @@ jobs:
       uses: "actions/checkout@v3"
 
     - name: "Clone website-sync Action"
-      run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+      # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+      # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+      # GitHub administrator to update the organization secret.
+      # The IT helpdesk can update the organization secret.
+      run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
 
     - name: "Publish to website repository (next)"
       uses: "./.github/actions/website-sync"
@@ -34,6 +38,10 @@ jobs:
         repository: "grafana/website"
         branch: "master"
         host: "github.com"
-        github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
+        # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+        # GitHub administrator to update the organization secret.
+        # The IT helpdesk can update the organization secret.
+        github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
         source_folder: "docs/sources"
         target_folder: "content/docs/phlare/next"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -56,7 +56,11 @@ jobs:
 
     - name: "Clone website-sync Action"
       if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-      run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+      # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+      # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+      # GitHub administrator to update the organization secret.
+      # The IT helpdesk can update the organization secret.
+      run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
 
     - name: "Publish to website repository (release)"
       if: "steps.has-matching-release-tag.outputs.bool == 'true'"
@@ -66,7 +70,11 @@ jobs:
         repository: "grafana/website"
         branch: "master"
         host: "github.com"
-        github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
+        # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+        # GitHub administrator to update the organization secret.
+        # The IT helpdesk can update the organization secret.
+        github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
         source_folder: "docs/sources"
         # Append ".x" to target to produce a v<major>.<minor>.x directory.
         target_folder: "content/docs/phlare/${{ steps.target.outputs.target }}.x"


### PR DESCRIPTION
The new tokens are managed centrally and have a longer expiry. Administrators of the grafanabot account will be
notified of the pending expiry and the secret can be rotated centrally without the need for a repository administrator to update their secrets.

The existing repository secrets can safely be removed. The tokens for those secrets will be removed by the end of this week.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
(cherry picked from commit 3bdc62b24f0516eca4dc1b9026a5ef5e475af80c)