### PR TITLE
Improve Worker timeout

### DIFF
--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -52,6 +52,7 @@ type Config struct {
 
 	// This configuration is injected internally.
 	QuerySchedulerDiscovery schedulerdiscovery.Config `yaml:"-"`
+	MaxLoopDuration         time.Duration             `yaml:"-"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -305,13 +305,18 @@ func (f *Phlare) initServer() (services.Service, error) {
 	// see https://github.com/grafana/phlare/issues/231
 	f.Cfg.Server.DoNotAddDefaultHTTPMiddleware = true
 
+	f.setupWorkerTimeout()
+	if f.isModuleActive(QueryScheduler) {
+		// to ensure that the query scheduler is always able to handle the request, we need to double the timeout
+		f.Cfg.Server.HTTPServerReadTimeout = 2 * f.Cfg.Server.HTTPServerReadTimeout
+		f.Cfg.Server.HTTPServerWriteTimeout = 2 * f.Cfg.Server.HTTPServerWriteTimeout
+	}
 	serv, err := server.New(f.Cfg.Server)
 	if err != nil {
 		return nil, err
 	}
 
 	f.Server = serv
-	f.setupWorkerTimeout()
 
 	servicesToWaitFor := func() []services.Service {
 		svs := []services.Service(nil)

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
-	"github.com/bufbuild/connect-go"
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -116,28 +116,24 @@ func (f *Phlare) initQueryScheduler() (services.Service, error) {
 		return nil, errors.Wrap(err, "query-scheduler init")
 	}
 	schedulerpbconnect.RegisterSchedulerForFrontendHandler(f.Server.HTTP, s)
-	schedulerpbconnect.RegisterSchedulerForQuerierHandler(f.Server.HTTP, s, f.schedulerQuerierTimeout())
+	schedulerpbconnect.RegisterSchedulerForQuerierHandler(f.Server.HTTP, s)
 	return s, nil
 }
 
-// schedulerQuerierTimeout returns a HandlerOption that sets the timeout for the
-// communication between the scheduler and the querier.
-// This is required because connect streaming handler does not propagate timeouts
-// through the context.
-// Adding a timeout options to the handler enforce the timeout to be propagated
-// and cancel the stream if the timeout is reached.
-// Querier expects this and will gracefully reconnects.
-func (f *Phlare) schedulerQuerierTimeout() connect.HandlerOption {
-	opts := []connect.HandlerOption{}
+// setupWorkerTimeout sets the max loop duration for the querier worker and frontend worker
+// to 90% of the read or write http timeout, whichever is smaller.
+// This is to ensure that the worker doesn't timeout before the http handler and that the connection
+// is refreshed.
+func (f *Phlare) setupWorkerTimeout() {
 	timeout := f.Cfg.Server.HTTPServerReadTimeout
 	if f.Cfg.Server.HTTPServerWriteTimeout < timeout {
 		timeout = f.Cfg.Server.HTTPServerWriteTimeout
 	}
 
 	if timeout > 0 {
-		opts = append(opts, connect.WithInterceptors(util.WithTimeout(timeout)))
+		f.Cfg.Worker.MaxLoopDuration = time.Duration(float64(timeout) * 0.9)
+		f.Cfg.Frontend.MaxLoopDuration = time.Duration(float64(timeout) * 0.9)
 	}
-	return connect.WithHandlerOptions(opts...)
 }
 
 func (f *Phlare) initQuerier() (services.Service, error) {
@@ -315,6 +311,7 @@ func (f *Phlare) initServer() (services.Service, error) {
 	}
 
 	f.Server = serv
+	f.setupWorkerTimeout()
 
 	servicesToWaitFor := func() []services.Service {
 		svs := []services.Service(nil)

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -49,12 +49,11 @@ var processorBackoffConfig = backoff.Config{
 
 func newSchedulerProcessor(cfg Config, handler RequestHandler, log log.Logger, reg prometheus.Registerer) (*schedulerProcessor, []services.Service) {
 	p := &schedulerProcessor{
-		log:            log,
-		handler:        handler,
-		maxMessageSize: cfg.GRPCClientConfig.MaxSendMsgSize,
-		querierID:      cfg.QuerierID,
-		grpcConfig:     cfg.GRPCClientConfig,
-		//
+		log:             log,
+		handler:         handler,
+		maxMessageSize:  cfg.GRPCClientConfig.MaxSendMsgSize,
+		querierID:       cfg.QuerierID,
+		grpcConfig:      cfg.GRPCClientConfig,
 		maxLoopDuration: cfg.MaxLoopDuration,
 
 		schedulerClientFactory: func(conn *grpc.ClientConn) schedulerpb.SchedulerForQuerierClient {
@@ -160,6 +159,7 @@ func (sp *schedulerProcessor) querierLoop(parentCtx context.Context, schedulerCl
 						// In the meanwhile, the execution context has been explicitly canceled, so we should just terminate.
 						return
 					default:
+						// Wait and check again inflight queries.
 						time.Sleep(100 * time.Millisecond)
 					}
 				}

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -8,6 +8,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -37,6 +38,10 @@ import (
 	"github.com/grafana/phlare/pkg/util/httpgrpcutil"
 )
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 var processorBackoffConfig = backoff.Config{
 	MinBackoff: 250 * time.Millisecond,
 	MaxBackoff: 2 * time.Second,
@@ -49,6 +54,8 @@ func newSchedulerProcessor(cfg Config, handler RequestHandler, log log.Logger, r
 		maxMessageSize: cfg.GRPCClientConfig.MaxSendMsgSize,
 		querierID:      cfg.QuerierID,
 		grpcConfig:     cfg.GRPCClientConfig,
+		//
+		maxLoopDuration: cfg.MaxLoopDuration,
 
 		schedulerClientFactory: func(conn *grpc.ClientConn) schedulerpb.SchedulerForQuerierClient {
 			return schedulerpb.NewSchedulerForQuerierClient(conn)
@@ -78,11 +85,12 @@ func newSchedulerProcessor(cfg Config, handler RequestHandler, log log.Logger, r
 
 // Handles incoming queries from query-scheduler.
 type schedulerProcessor struct {
-	log            log.Logger
-	handler        RequestHandler
-	grpcConfig     grpcclient.Config
-	maxMessageSize int
-	querierID      string
+	log             log.Logger
+	handler         RequestHandler
+	grpcConfig      grpcclient.Config
+	maxMessageSize  int
+	querierID       string
+	maxLoopDuration time.Duration
 
 	frontendPool                  *client.Pool
 	frontendClientRequestDuration *prometheus.HistogramVec
@@ -111,42 +119,67 @@ func (sp *schedulerProcessor) processQueriesOnSingleStream(workerCtx context.Con
 
 	backoff := backoff.New(execCtx, processorBackoffConfig)
 	for backoff.Ongoing() {
-		c, err := schedulerClient.QuerierLoop(execCtx)
-		if err == nil {
-			err = c.Send(&schedulerpb.QuerierToScheduler{QuerierID: sp.querierID})
-		}
-
-		if err != nil {
-			level.Warn(sp.log).Log("msg", "error contacting scheduler", "err", err, "addr", address)
-			backoff.Wait()
-			continue
-		}
-
-		if err := sp.querierLoop(c, address, inflightQuery); err != nil {
-			// Do not log an error is the query-scheduler is shutting down.
-			if s, ok := status.FromError(err); !ok ||
-				(!strings.Contains(s.Message(), schedulerpb.ErrSchedulerIsNotRunning.Error()) &&
-					!strings.Contains(s.Message(), context.DeadlineExceeded.Error()) &&
-					!strings.Contains(s.Message(), "stream terminated")) {
-				level.Error(sp.log).Log("msg", "error processing requests from scheduler", "err", err, "addr", address)
+		func() {
+			if err := sp.querierLoop(execCtx, schedulerClient, address, inflightQuery); err != nil {
+				// Do not log an error is the query-scheduler is shutting down.
+				if s, ok := status.FromError(err); !ok ||
+					(!strings.Contains(s.Message(), schedulerpb.ErrSchedulerIsNotRunning.Error()) &&
+						!strings.Contains(s.Message(), context.Canceled.Error()) &&
+						!strings.Contains(s.Message(), "stream terminated")) {
+					level.Error(sp.log).Log("msg", "error processing requests from scheduler", "err", err, "addr", address)
+				}
+				if strings.Contains(err.Error(), context.Canceled.Error()) || strings.Contains(err.Error(), "stream terminated") {
+					backoff.Reset()
+					return
+				}
+				backoff.Wait()
+				return
 			}
-			if strings.Contains(err.Error(), context.DeadlineExceeded.Error()) || strings.Contains(err.Error(), "stream terminated") {
-				backoff.Reset()
-				continue
-			}
-			backoff.Wait()
-			continue
-		}
 
-		backoff.Reset()
+			backoff.Reset()
+		}()
 	}
 }
 
 // process loops processing requests on an established stream.
-func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_QuerierLoopClient, address string, inflightQuery *atomic.Bool) error {
-	// Build a child context so we can cancel a query when the stream is closed.
-	ctx, cancel := context.WithCancel(c.Context())
-	defer cancel()
+func (sp *schedulerProcessor) querierLoop(parentCtx context.Context, schedulerClient schedulerpb.SchedulerForQuerierClient, address string, inflightQuery *atomic.Bool) error {
+	loopCtx, loopCancel := context.WithCancel(parentCtx)
+	defer loopCancel()
+
+	if sp.maxLoopDuration > 0 {
+		go func() {
+			timer := time.NewTimer(jitter(sp.maxLoopDuration, 0.3))
+			defer timer.Stop()
+
+			select {
+			case <-timer.C:
+				level.Debug(sp.log).Log("msg", "waiting for inflight queries to complete")
+				for inflightQuery.Load() {
+					select {
+					case <-parentCtx.Done():
+						// In the meanwhile, the execution context has been explicitly canceled, so we should just terminate.
+						return
+					default:
+						time.Sleep(100 * time.Millisecond)
+					}
+				}
+				level.Debug(sp.log).Log("msg", "refreshing scheduler connection")
+				loopCancel()
+			case <-parentCtx.Done():
+				return
+			}
+		}()
+	}
+
+	c, err := schedulerClient.QuerierLoop(loopCtx)
+	if err == nil {
+		err = c.Send(&schedulerpb.QuerierToScheduler{QuerierID: sp.querierID})
+	}
+
+	if err != nil {
+		level.Warn(sp.log).Log("msg", "error contacting scheduler", "err", err, "addr", address)
+		return err
+	}
 
 	for {
 		request, err := c.Recv()
@@ -165,7 +198,7 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 			defer inflightQuery.Store(false)
 
 			// We need to inject user into context for sending response back.
-			ctx := user.InjectOrgID(ctx, request.UserID)
+			ctx := user.InjectOrgID(c.Context(), request.UserID)
 
 			tracer := opentracing.GlobalTracer()
 			// Ignore errors here. If we cannot get parent span, we just don't create new one.
@@ -186,6 +219,11 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 			}
 		}()
 	}
+}
+
+func jitter(d time.Duration, factor float64) time.Duration {
+	maxJitter := time.Duration(float64(d) * factor)
+	return d - time.Duration(rand.Int63n(int64(maxJitter)))
 }
 
 func (sp *schedulerProcessor) runRequest(ctx context.Context, logger log.Logger, queryID uint64, frontendAddress string, statsEnabled bool, request *httpgrpc.HTTPRequest) {

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -35,6 +35,7 @@ type Config struct {
 	// This configuration is injected internally.
 	MaxConcurrentRequests   int                       `yaml:"-"` // Must be same as passed to PromQL Engine.
 	QuerySchedulerDiscovery schedulerdiscovery.Config `yaml:"-"`
+	MaxLoopDuration         time.Duration             `yaml:"-"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -212,9 +212,7 @@ func (s *Scheduler) FrontendLoop(ctx context.Context, frontend *connect.BidiStre
 	if err != nil {
 		return err
 	}
-	defer func() {
-		s.frontendDisconnected(frontendAddress)
-	}()
+	defer s.frontendDisconnected(frontendAddress)
 
 	// Response to INIT. If scheduler is not running, we skip for-loop, send SHUTTING_DOWN and exit this method.
 	if s.State() == services.Running {
@@ -427,9 +425,7 @@ func (s *Scheduler) QuerierLoop(ctx context.Context, bidi *connect.BidiStream[sc
 	querierID := resp.GetQuerierID()
 
 	s.requestQueue.RegisterQuerierConnection(querierID)
-	defer func() {
-		s.requestQueue.UnregisterQuerierConnection(querierID)
-	}()
+	defer s.requestQueue.UnregisterQuerierConnection(querierID)
 
 	lastUserIndex := queue.FirstUser()
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -212,7 +212,9 @@ func (s *Scheduler) FrontendLoop(ctx context.Context, frontend *connect.BidiStre
 	if err != nil {
 		return err
 	}
-	defer s.frontendDisconnected(frontendAddress)
+	defer func() {
+		s.frontendDisconnected(frontendAddress)
+	}()
 
 	// Response to INIT. If scheduler is not running, we skip for-loop, send SHUTTING_DOWN and exit this method.
 	if s.State() == services.Running {
@@ -425,7 +427,9 @@ func (s *Scheduler) QuerierLoop(ctx context.Context, bidi *connect.BidiStream[sc
 	querierID := resp.GetQuerierID()
 
 	s.requestQueue.RegisterQuerierConnection(querierID)
-	defer s.requestQueue.UnregisterQuerierConnection(querierID)
+	defer func() {
+		s.requestQueue.UnregisterQuerierConnection(querierID)
+	}()
 
 	lastUserIndex := queue.FirstUser()
 


### PR DESCRIPTION
This PR ensures the worker and frontend loop will automatically disconnect and reconnect before the handler timeout.

To ensure a query does not time out right after being processed in the querier we also increase the scheduler timeout by 2.