### PR TITLE
Use the correct API in readyHandler

### DIFF
--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -400,7 +400,7 @@ func (f *Phlare) readyHandler(sm *services.Manager) http.HandlerFunc {
 			return
 		}
 
-		http.Error(w, "ready", http.StatusOK)
+		util.WriteTextResponse(w, "ready")
 	}
 }
 

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -323,3 +323,11 @@ func WriteHTMLResponse(w http.ResponseWriter, message string) {
 	// Ignore inactionable errors.
 	_, _ = w.Write([]byte(message))
 }
+
+// WriteTextResponse sends message as text/plain response with 200 status code.
+func WriteTextResponse(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "text/plain")
+
+	// Ignore inactionable errors.
+	_, _ = w.Write([]byte(message))
+}

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -1,0 +1,20 @@
+package util_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/phlare/pkg/util"
+)
+
+func TestWriteTextResponse(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	util.WriteTextResponse(w, "hello world")
+
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "hello world", w.Body.String())
+	assert.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+}


### PR DESCRIPTION
I guess it's better to use the correct API to give an OK response. We should not use `http.Error` here.