### PR TITLE
Use generic writer in deduplicatingSlice

### DIFF
--- a/pkg/phlaredb/deduplicating_slice.go
+++ b/pkg/phlaredb/deduplicating_slice.go
@@ -39,7 +39,7 @@ type deduplicatingSlice[M Models, K comparable, H Helper[M, K], P schemav1.Persi
 
 	file   *os.File
 	cfg    *ParquetConfig
-	writer *parquet.Writer
+	writer *parquet.GenericWriter[P]
 
 	buffer      *parquet.Buffer
 	rowsFlushed int
@@ -66,7 +66,7 @@ func (s *deduplicatingSlice[M, K, H, P]) Init(path string, cfg *ParquetConfig) e
 	s.file = file
 
 	// TODO: Reuse parquet.Writer beyond life time of the head.
-	s.writer = parquet.NewWriter(file, s.persister.Schema(),
+	s.writer = parquet.NewGenericWriter[P](file, s.persister.Schema(),
 		parquet.ColumnPageBuffers(parquet.NewFileBufferPool(os.TempDir(), "phlaredb-parquet-buffers*")),
 		parquet.CreatedBy("github.com/grafana/phlare/", build.Version, build.Revision),
 	)


### PR DESCRIPTION
`parquet.Writer` is deprcated.