### PR TITLE
Ingester limits

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/phlare/pkg/tenant"
 	"github.com/grafana/phlare/pkg/usagestats"
 	"github.com/grafana/phlare/pkg/util"
+	"github.com/grafana/phlare/pkg/validation"
 )
 
 var activeTenantsStats = usagestats.NewInt("ingester_active_tenants")
@@ -57,7 +58,8 @@ type Ingester struct {
 	instances    map[string]*instance
 	instancesMtx sync.RWMutex
 
-	reg prometheus.Registerer
+	limits Limits
+	reg    prometheus.Registerer
 }
 
 type ingesterFlusherCompat struct {
@@ -71,7 +73,7 @@ func (i *ingesterFlusherCompat) Flush() {
 	}
 }
 
-func New(phlarectx context.Context, cfg Config, dbConfig phlaredb.Config, storageBucket phlareobjstore.Bucket) (*Ingester, error) {
+func New(phlarectx context.Context, cfg Config, dbConfig phlaredb.Config, storageBucket phlareobjstore.Bucket, limits Limits) (*Ingester, error) {
 	i := &Ingester{
 		cfg:           cfg,
 		phlarectx:     phlarectx,
@@ -80,6 +82,7 @@ func New(phlarectx context.Context, cfg Config, dbConfig phlaredb.Config, storag
 		instances:     map[string]*instance{},
 		dbConfig:      dbConfig,
 		storageBucket: storageBucket,
+		limits:        limits,
 	}
 
 	var err error
@@ -135,7 +138,8 @@ func (i *Ingester) GetOrCreateInstance(tenantID string) (*instance, error) { //n
 	inst, ok = i.instances[tenantID]
 	if !ok {
 		var err error
-		inst, err = newInstance(i.phlarectx, i.dbConfig, tenantID, i.storageBucket)
+
+		inst, err = newInstance(i.phlarectx, i.dbConfig, tenantID, i.storageBucket, NewLimiter(tenantID, i.limits, i.lifecycler, i.cfg.LifecyclerConfig.RingConfig.ReplicationFactor))
 		if err != nil {
 			return nil, err
 		}
@@ -184,16 +188,26 @@ func (i *Ingester) Push(ctx context.Context, req *connect.Request[pushv1.PushReq
 		level.Debug(instance.logger).Log("msg", "message received by ingester push")
 		for _, series := range req.Msg.Series {
 			for _, sample := range series.Samples {
-				p, err := pprof.FromBytes(sample.RawProfile)
+				p, size, err := pprof.FromBytes(sample.RawProfile)
 				if err != nil {
 					return nil, err
 				}
-
 				id, err := uuid.Parse(sample.ID)
 				if err != nil {
 					return nil, err
 				}
 				if err := instance.Head().Ingest(ctx, p, id, series.Labels...); err != nil {
+					reason := validation.ReasonOf(err)
+					if reason != validation.Unknown {
+						validation.DiscardedProfiles.WithLabelValues(string(reason), instance.tenantID).Add(float64(1))
+						validation.DiscardedBytes.WithLabelValues(string(reason), instance.tenantID).Add(float64(size))
+						switch validation.ReasonOf(err) {
+						case validation.OutOfOrder:
+							return nil, connect.NewError(connect.CodeInvalidArgument, err)
+						case validation.StreamLimit:
+							return nil, connect.NewError(connect.CodeResourceExhausted, err)
+						}
+					}
 					return nil, err
 				}
 				p.ReturnToVTPool()

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -204,7 +204,7 @@ func (i *Ingester) Push(ctx context.Context, req *connect.Request[pushv1.PushReq
 						switch validation.ReasonOf(err) {
 						case validation.OutOfOrder:
 							return nil, connect.NewError(connect.CodeInvalidArgument, err)
-						case validation.StreamLimit:
+						case validation.SeriesLimit:
 							return nil, connect.NewError(connect.CodeResourceExhausted, err)
 						}
 					}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -57,12 +57,13 @@ func Test_MultitenantReadWrite(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	ctx := phlarecontext.WithLogger(context.Background(), logger)
 	ctx = phlarecontext.WithRegistry(ctx, reg)
-	cfg := client.Config{StorageBackendConfig: client.StorageBackendConfig{
-		Backend: client.Filesystem,
-		Filesystem: filesystem.Config{
-			Directory: dbPath,
+	cfg := client.Config{
+		StorageBackendConfig: client.StorageBackendConfig{
+			Backend: client.Filesystem,
+			Filesystem: filesystem.Config{
+				Directory: dbPath,
+			},
 		},
-	},
 	}
 
 	fs, err := client.NewBucket(ctx, cfg, "storage")
@@ -71,7 +72,7 @@ func Test_MultitenantReadWrite(t *testing.T) {
 	ing, err := New(ctx, defaultIngesterTestConfig(t), phlaredb.Config{
 		DataPath:         dbPath,
 		MaxBlockDuration: 30 * time.Hour,
-	}, fs)
+	}, fs, &fakeLimits{})
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))
 

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -161,7 +161,7 @@ func (l *limiter) assertMaxSeriesPerUser(tenantID string, series int) error {
 	if series < calculatedLimit {
 		return nil
 	}
-	return validation.NewErrorf(validation.StreamLimit, validation.StreamLimitErrorMsg, series, calculatedLimit)
+	return validation.NewErrorf(validation.SeriesLimit, validation.SeriesLimitErrorMsg, series, calculatedLimit)
 }
 
 func convertGlobalToLocalLimit(globalLimit int, ringCount RingCount, replicationFactor int) int {

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -1,0 +1,193 @@
+package ingester
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	phlaremodel "github.com/grafana/phlare/pkg/model"
+	"github.com/grafana/phlare/pkg/validation"
+)
+
+var (
+	activeSeriesTimeout = 10 * time.Minute
+	activeSeriesCleanup = time.Minute
+)
+
+type RingCount interface {
+	HealthyInstancesCount() int
+}
+
+type Limits interface {
+	MaxLocalSeriesPerUser(userID string) int
+	MaxGlobalSeriesPerUser(userID string) int
+}
+
+type Limiter interface {
+	// AllowProfile returns an error if the profile is not allowed to be ingested.
+	// The error is a validation error and can be out of order or max series limit reached.
+	AllowProfile(fp model.Fingerprint, lbs phlaremodel.Labels, tsNano int64) error
+	Stop()
+}
+
+type limiter struct {
+	limits            Limits
+	ring              RingCount
+	replicationFactor int
+	tenantID          string
+
+	activeSeries  map[model.Fingerprint]int64
+	lastTimestamp map[model.Fingerprint]int64
+
+	mtx sync.Mutex // todo: may be shard the lock to avoid latency spikes.
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func NewLimiter(tenantID string, limits Limits, ring RingCount, replicationFactor int) Limiter {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	l := &limiter{
+		tenantID:          tenantID,
+		limits:            limits,
+		ring:              ring,
+		replicationFactor: replicationFactor,
+		activeSeries:      map[model.Fingerprint]int64{},
+		lastTimestamp:     map[model.Fingerprint]int64{},
+		cancel:            cancel,
+		ctx:               ctx,
+	}
+
+	l.wg.Add(1)
+	go l.loop()
+
+	return l
+}
+
+func (l *limiter) Stop() {
+	l.cancel()
+	l.wg.Wait()
+}
+
+func (l *limiter) loop() {
+	defer l.wg.Done()
+
+	ticker := time.NewTicker(activeSeriesCleanup)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			l.cleanup()
+		case <-l.ctx.Done():
+			return
+		}
+	}
+}
+
+// cleanup removes the series that have not been used for a while.
+func (l *limiter) cleanup() {
+	now := time.Now().UnixNano()
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	for fp, lastUsed := range l.activeSeries {
+		if now-lastUsed > int64(activeSeriesTimeout) {
+			delete(l.activeSeries, fp)
+		}
+	}
+}
+
+func (l *limiter) AllowProfile(fp model.Fingerprint, lbs phlaremodel.Labels, tsNano int64) error {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	if err := l.allowNewProfile(fp, lbs, tsNano); err != nil {
+		return err
+	}
+	return l.allowNewSeries(fp)
+}
+
+func (l *limiter) allowNewProfile(fp model.Fingerprint, lbs phlaremodel.Labels, tsNano int64) error {
+	max, ok := l.lastTimestamp[fp]
+	if ok {
+		// profile is before the last timestamp
+		if tsNano < max {
+			return validation.NewErrorf(validation.OutOfOrder, "profile for series %s out of order (received %s last %s)", phlaremodel.LabelPairsString(lbs), time.Unix(0, tsNano), time.Unix(0, max))
+		}
+	}
+
+	// set the last timestamp
+	l.lastTimestamp[fp] = tsNano
+	return nil
+}
+
+func (l *limiter) allowNewSeries(fp model.Fingerprint) error {
+	_, ok := l.activeSeries[fp]
+	series := len(l.activeSeries)
+	if !ok {
+		// can this series be added?
+		if err := l.assertMaxSeriesPerUser(l.tenantID, series); err != nil {
+			return err
+		}
+	}
+
+	// update time or add it
+	l.activeSeries[fp] = time.Now().UnixNano()
+	return nil
+}
+
+func (l *limiter) assertMaxSeriesPerUser(tenantID string, series int) error {
+	// Start by setting the local limit either from override or default
+	localLimit := l.limits.MaxLocalSeriesPerUser(tenantID)
+
+	// We can assume that series are evenly distributed across ingesters
+	// so we do convert the global limit into a local limit
+	globalLimit := l.limits.MaxGlobalSeriesPerUser(tenantID)
+	adjustedGlobalLimit := convertGlobalToLocalLimit(globalLimit, l.ring, l.replicationFactor)
+
+	// Set the calculated limit to the lesser of the local limit or the new calculated global limit
+	calculatedLimit := minNonZero(localLimit, adjustedGlobalLimit)
+
+	// If both the local and global limits are disabled, we just
+	// use the largest int value
+	if calculatedLimit == 0 {
+		return nil
+	}
+
+	if series < calculatedLimit {
+		return nil
+	}
+	return validation.NewErrorf(validation.StreamLimit, validation.StreamLimitErrorMsg, series, calculatedLimit)
+}
+
+func convertGlobalToLocalLimit(globalLimit int, ringCount RingCount, replicationFactor int) int {
+	if globalLimit == 0 {
+		return 0
+	}
+
+	// Given we don't need a super accurate count (ie. when the ingesters
+	// topology changes) and we prefer to always be in favor of the tenant,
+	// we can use a per-ingester limit equal to:
+	// (global limit / number of ingesters) * replication factor
+	numIngesters := ringCount.HealthyInstancesCount()
+
+	// May happen because the number of ingesters is asynchronously updated.
+	// If happens, we just temporarily ignore the global limit.
+	if numIngesters > 0 {
+		return int((float64(globalLimit) / float64(numIngesters)) * float64(replicationFactor))
+	}
+
+	return 0
+}
+
+func minNonZero(first, second int) int {
+	if first == 0 || (second != 0 && first > second) {
+		return second
+	}
+
+	return first
+}

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -1,0 +1,92 @@
+package ingester
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	phlaremodel "github.com/grafana/phlare/pkg/model"
+)
+
+type fakeLimits struct {
+	maxLocalSeriesPerUser  int
+	maxGlobalSeriesPerUser int
+}
+
+func (f *fakeLimits) MaxLocalSeriesPerUser(userID string) int {
+	return f.maxLocalSeriesPerUser
+}
+
+func (f *fakeLimits) MaxGlobalSeriesPerUser(userID string) int {
+	return f.maxGlobalSeriesPerUser
+}
+
+type fakeRingCount struct {
+	healthyInstancesCount int
+}
+
+func (f *fakeRingCount) HealthyInstancesCount() int {
+	return f.healthyInstancesCount
+}
+
+func TestOutOfOrder(t *testing.T) {
+	limiter := NewLimiter("foo", &fakeLimits{}, &fakeRingCount{1}, 1)
+	defer limiter.Stop()
+
+	// First push should be allowed.
+	err := limiter.AllowProfile(1, phlaremodel.LabelsFromStrings("foo", "bar"), 5)
+	require.NoError(t, err)
+
+	// different stream should be allowed.
+	err = limiter.AllowProfile(2, phlaremodel.LabelsFromStrings("foo", "baz"), 1)
+	require.NoError(t, err)
+
+	err = limiter.AllowProfile(1, phlaremodel.LabelsFromStrings("foo", "baz"), 1)
+	require.Error(t, err)
+}
+
+func TestGlobalMaxSeries(t *testing.T) {
+	// 5 series per user, 2 ingesters, replication factor 3.
+	// We should be able to push 7.5 series. (5 / 2 * 3 = 7.5)
+	activeSeriesTimeout = 200 * time.Millisecond
+	activeSeriesCleanup = 100 * time.Millisecond
+
+	limiter := NewLimiter("foo", &fakeLimits{maxGlobalSeriesPerUser: 5}, &fakeRingCount{2}, 3)
+	defer limiter.Stop()
+
+	for i := 0; i < 7; i++ {
+		err := limiter.AllowProfile(model.Fingerprint(i), phlaremodel.LabelsFromStrings("i", fmt.Sprintf("%d", i)), 0)
+		require.NoError(t, err)
+	}
+
+	err := limiter.AllowProfile(8, phlaremodel.LabelsFromStrings("i", "8"), 0)
+	require.Error(t, err)
+
+	// Wait for cleanup to happen.
+	time.Sleep(400 * time.Millisecond)
+
+	// Now we should be able to push 5 series.
+	for i := 0; i < 5; i++ {
+		err := limiter.AllowProfile(model.Fingerprint(i), phlaremodel.LabelsFromStrings("i", fmt.Sprintf("%d", i)), 0)
+		require.NoError(t, err)
+	}
+}
+
+func TestLocalLimit(t *testing.T) {
+	activeSeriesTimeout = 200 * time.Millisecond
+	activeSeriesCleanup = 100 * time.Millisecond
+
+	limiter := NewLimiter("foo", &fakeLimits{maxGlobalSeriesPerUser: 5, maxLocalSeriesPerUser: 1}, &fakeRingCount{2}, 3)
+	defer limiter.Stop()
+
+	// local limit of 1 series should take precedence over global limit of 5 series.
+
+	err := limiter.AllowProfile(1, phlaremodel.LabelsFromStrings("i", "1"), 0)
+	require.NoError(t, err)
+
+	err = limiter.AllowProfile(2, phlaremodel.LabelsFromStrings("i", "2"), 0)
+	require.Error(t, err)
+}

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -342,7 +342,7 @@ func (f *Phlare) context() context.Context {
 func (f *Phlare) initIngester() (_ services.Service, err error) {
 	f.Cfg.Ingester.LifecyclerConfig.ListenPort = f.Cfg.Server.HTTPListenPort
 
-	ingester, err := ingester.New(f.context(), f.Cfg.Ingester, f.Cfg.PhlareDB, f.storageBucket)
+	ingester, err := ingester.New(f.context(), f.Cfg.Ingester, f.Cfg.PhlareDB, f.storageBucket, f.Overrides)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/phlaredb/phlaredb.go
+++ b/pkg/phlaredb/phlaredb.go
@@ -74,6 +74,11 @@ func (*realFileSystem) Open(name string) (fs.File, error)          { return os.O
 func (*realFileSystem) ReadDir(name string) ([]fs.DirEntry, error) { return os.ReadDir(name) }
 func (*realFileSystem) RemoveAll(path string) error                { return os.RemoveAll(path) }
 
+type TenantLimiter interface {
+	AllowProfile(fp model.Fingerprint, lbs phlaremodel.Labels, tsNano int64) error
+	Stop()
+}
+
 type PhlareDB struct {
 	services.Service
 
@@ -93,9 +98,10 @@ type PhlareDB struct {
 	headFlushTimer time.Timer
 
 	blockQuerier *BlockQuerier
+	limiter      TenantLimiter
 }
 
-func New(phlarectx context.Context, cfg Config) (*PhlareDB, error) {
+func New(phlarectx context.Context, cfg Config, limiter TenantLimiter) (*PhlareDB, error) {
 	fs, err := filesystem.NewBucket(cfg.DataPath)
 	if err != nil {
 		return nil, err
@@ -109,7 +115,8 @@ func New(phlarectx context.Context, cfg Config) (*PhlareDB, error) {
 			minFreeDisk,
 			minDiskAvailablePercentage,
 		),
-		fs: &realFileSystem{},
+		fs:      &realFileSystem{},
+		limiter: limiter,
 	}
 	if err := os.MkdirAll(f.LocalDataPath(), 0o777); err != nil {
 		return nil, fmt.Errorf("mkdir %s: %w", f.LocalDataPath(), err)
@@ -282,6 +289,7 @@ func (f *PhlareDB) Close() error {
 	if err := f.blockQuerier.Close(); err != nil {
 		errs.Add(err)
 	}
+	f.limiter.Stop()
 	return errs.Err()
 }
 
@@ -435,7 +443,7 @@ func (f *PhlareDB) initHead() (oldHead *Head, err error) {
 	f.headLock.Lock()
 	defer f.headLock.Unlock()
 	oldHead = f.head
-	f.head, err = NewHead(f.phlarectx, f.cfg)
+	f.head, err = NewHead(f.phlarectx, f.cfg, f.limiter)
 	if err != nil {
 		return oldHead, err
 	}

--- a/pkg/phlaredb/phlaredb_test.go
+++ b/pkg/phlaredb/phlaredb_test.go
@@ -42,13 +42,13 @@ func TestCreateLocalDir(t *testing.T) {
 	_, err := New(context.Background(), Config{
 		DataPath:         dataPath,
 		MaxBlockDuration: 30 * time.Minute,
-	})
+	}, NoLimit)
 	require.Error(t, err)
 	require.NoError(t, os.Remove(localFile))
 	_, err = New(context.Background(), Config{
 		DataPath:         dataPath,
 		MaxBlockDuration: 30 * time.Minute,
-	})
+	}, NoLimit)
 	require.NoError(t, err)
 }
 
@@ -143,7 +143,7 @@ func TestMergeProfilesStacktraces(t *testing.T) {
 	db, err := New(context.Background(), Config{
 		DataPath:         testDir,
 		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-	})
+	}, NoLimit)
 	require.NoError(t, err)
 	defer require.NoError(t, db.Close())
 
@@ -271,7 +271,7 @@ func TestMergeProfilesPprof(t *testing.T) {
 	db, err := New(context.Background(), Config{
 		DataPath:         testDir,
 		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-	})
+	}, NoLimit)
 	require.NoError(t, err)
 	defer require.NoError(t, db.Close())
 
@@ -470,6 +470,7 @@ func (f *fakeVolumeFS) Open(path string) (fs.File, error) {
 	args := f.Called(path)
 	return args[0].(fs.File), args.Error(1)
 }
+
 func (f *fakeVolumeFS) RemoveAll(path string) error {
 	args := f.Called(path)
 	return args.Error(0)

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -49,7 +49,7 @@ type profileStore struct {
 }
 
 func newProfileStore(phlarectx context.Context) *profileStore {
-	var s = &profileStore{
+	s := &profileStore{
 		logger:    phlarecontext.Logger(phlarectx),
 		metrics:   contextHeadMetrics(phlarectx),
 		persister: &schemav1.ProfilePersister{},
@@ -105,7 +105,6 @@ func (s *profileStore) Close() error {
 }
 
 func (s *profileStore) RowGroups() (rowGroups []parquet.RowGroup) {
-
 	rowGroups = make([]parquet.RowGroup, len(s.rowGroups))
 	for pos := range rowGroups {
 		rowGroups[pos] = s.rowGroups[pos]
@@ -134,7 +133,6 @@ func (s *profileStore) profileSort(i, j int) bool {
 
 	// finally use ID as tie breaker
 	return bytes.Compare(pI.ID[:], pJ.ID[:]) < 0
-
 }
 
 func (s *profileStore) Flush(ctx context.Context) (numRows uint64, numRowGroups uint64, err error) {
@@ -358,7 +356,6 @@ func newRowGroupOnDisk(path string) (*rowGroupOnDisk, error) {
 	r.RowGroup = rowGroups[0]
 
 	return r, nil
-
 }
 
 func (r *rowGroupOnDisk) RowGroups() []parquet.RowGroup {
@@ -395,7 +392,6 @@ func (r *rowGroupOnDisk) columnIter(ctx context.Context, columnName string, pred
 		return query.NewErrIterator(fmt.Errorf("column '%s' not found in head row group segment '%s'", columnName, r.file.Name()))
 	}
 	return query.NewColumnIterator(ctx, []parquet.RowGroup{r.RowGroup}, column.ColumnIndex, columnName, 1000, predicate, alias)
-
 }
 
 type seriesIDRowsRewriter struct {

--- a/pkg/phlaredb/profile_store_test.go
+++ b/pkg/phlaredb/profile_store_test.go
@@ -55,7 +55,6 @@ func (tp *testProfile) populateFingerprint() {
 	lbls := phlaremodel.NewLabelsBuilder(tp.lbls)
 	lbls.Set(model.MetricNameLabel, tp.profileName)
 	tp.p.SeriesFingerprint = model.Fingerprint(lbls.Labels().Hash())
-
 }
 
 func sameProfileStream(i int) *testProfile {
@@ -168,7 +167,6 @@ func TestProfileStore_RowGroupSplitting(t *testing.T) {
 			assert.Equal(t, "00000000-0000-0000-0000-000000000000", rows[0].ID.String())
 			assert.Equal(t, "00000000-0000-0000-0000-000000000001", rows[1].ID.String())
 			assert.Equal(t, "00000000-0000-0000-0000-000000000002", rows[2].ID.String())
-
 		})
 	}
 }
@@ -236,13 +234,12 @@ func ingestThreeProfileStreams(ctx context.Context, i int, ingest func(context.C
 
 // TestProfileStore_Querying
 func TestProfileStore_Querying(t *testing.T) {
-
 	var (
 		ctx = testContext(t)
 		cfg = Config{
 			DataPath: t.TempDir(),
 		}
-		head, err = NewHead(ctx, cfg)
+		head, err = NewHead(ctx, cfg, NoLimit)
 	)
 	require.NoError(t, err)
 
@@ -470,5 +467,4 @@ func TestProfileStore_Querying(t *testing.T) {
 			values,
 		)
 	})
-
 }

--- a/pkg/phlaredb/profile_test.go
+++ b/pkg/phlaredb/profile_test.go
@@ -165,12 +165,12 @@ func Test_rowRangeIter(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			it := rowRanges{tc.r: 0xff}.iter()
-			var result = []int64{}
+			result := []int64{}
 			for it.Next() {
 				result = append(result, it.At().RowNumber())
+				assert.Equal(t, model.Fingerprint(0xff), it.At().fp)
 			}
 			assert.Equal(t, tc.expected, result)
 		})
 	}
-
 }

--- a/pkg/phlaredb/profiles.go
+++ b/pkg/phlaredb/profiles.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"sync"
-	"time"
 	"unsafe"
 
 	"github.com/gogo/status"
@@ -25,7 +24,6 @@ import (
 	schemav1 "github.com/grafana/phlare/pkg/phlaredb/schemas/v1"
 	"github.com/grafana/phlare/pkg/phlaredb/tsdb"
 	"github.com/grafana/phlare/pkg/phlaredb/tsdb/index"
-	"github.com/grafana/phlare/pkg/validation"
 )
 
 // delta encoding for ranges
@@ -174,12 +172,11 @@ func newProfileIndex(totalShards uint32, metrics *headMetrics) (*profilesIndex, 
 
 // Add a new set of profile to the index.
 // The seriesRef are expected to match the profile labels passed in.
-func (pi *profilesIndex) Add(ps *schemav1.Profile, lbs phlaremodel.Labels, profileName string) error {
+func (pi *profilesIndex) Add(ps *schemav1.Profile, lbs phlaremodel.Labels, profileName string) {
 	pi.mutex.Lock()
 	defer pi.mutex.Unlock()
 	profiles, ok := pi.profilesPerFP[ps.SeriesFingerprint]
 	if !ok {
-		// todo pre creation check if the series can be created.
 		lbs := pi.ix.Add(lbs, ps.SeriesFingerprint)
 		profiles = &profileSeries{
 			lbs:     lbs,
@@ -191,10 +188,7 @@ func (pi *profilesIndex) Add(ps *schemav1.Profile, lbs phlaremodel.Labels, profi
 		pi.totalSeries.Inc()
 		pi.metrics.seriesCreated.WithLabelValues(profileName).Inc()
 	}
-	// post creation check if the profile is valid
-	if ps.TimeNanos < profiles.maxTime {
-		return validation.NewErrorf(validation.OutOfOrder, "profile for series %s out of order (received %s last %s)", phlaremodel.LabelPairsString(lbs), time.Unix(0, ps.TimeNanos), time.Unix(0, profiles.maxTime))
-	}
+
 	profiles.profiles = append(profiles.profiles, ps)
 	if ps.TimeNanos < profiles.minTime {
 		profiles.minTime = ps.TimeNanos

--- a/pkg/phlaredb/sample_merge_test.go
+++ b/pkg/phlaredb/sample_merge_test.go
@@ -125,7 +125,7 @@ func TestMergeSampleByStacktraces(t *testing.T) {
 			db, err := New(context.Background(), Config{
 				DataPath:         testPath,
 				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-			})
+			}, NoLimit)
 			require.NoError(t, err)
 			ctx := context.Background()
 
@@ -268,7 +268,7 @@ func TestHeadMergeSampleByStacktraces(t *testing.T) {
 			db, err := New(context.Background(), Config{
 				DataPath:         testPath,
 				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-			})
+			}, NoLimit)
 			require.NoError(t, err)
 			ctx := context.Background()
 
@@ -385,7 +385,7 @@ func TestMergeSampleByLabels(t *testing.T) {
 			db, err := New(context.Background(), Config{
 				DataPath:         testPath,
 				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-			})
+			}, NoLimit)
 			require.NoError(t, err)
 			ctx := context.Background()
 
@@ -510,7 +510,7 @@ func TestHeadMergeSampleByLabels(t *testing.T) {
 			db, err := New(context.Background(), Config{
 				DataPath:         testPath,
 				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-			})
+			}, NoLimit)
 			require.NoError(t, err)
 			ctx := context.Background()
 
@@ -548,7 +548,7 @@ func TestMergePprof(t *testing.T) {
 	db, err := New(context.Background(), Config{
 		DataPath:         testPath,
 		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-	})
+	}, NoLimit)
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -603,7 +603,7 @@ func TestHeadMergePprof(t *testing.T) {
 	db, err := New(context.Background(), Config{
 		DataPath:         testPath,
 		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-	})
+	}, NoLimit)
 	require.NoError(t, err)
 	ctx := context.Background()
 

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -99,16 +99,16 @@ func RawFromBytes(input []byte) (*Profile, error) {
 }
 
 // Read Profile from Bytes
-func FromBytes(input []byte) (*profilev1.Profile, error) {
+func FromBytes(input []byte) (*profilev1.Profile, int, error) {
 	p, err := RawFromBytes(input)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-
+	uncompressedSize := p.buf.Len()
 	p.buf.Reset()
 	bufPool.Put(p.buf)
 
-	return p.Profile, nil
+	return p.Profile, uncompressedSize, nil
 }
 
 func FromProfile(p *profile.Profile) (*profilev1.Profile, error) {

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -18,6 +18,7 @@ type Reason string
 
 const (
 	ReasonLabel string = "reason"
+	Unknown     Reason = "unknown"
 	// InvalidLabels is a reason for discarding profiles which have labels that are invalid.
 	InvalidLabels Reason = "invalid_labels"
 	// MissingLabels is a reason for discarding profiles which have no labels.
@@ -35,7 +36,11 @@ const (
 	LabelValueTooLong Reason = "label_value_too_long"
 	// DuplicateLabelNames is a reason for discarding a request which has duplicate label names
 	DuplicateLabelNames Reason = "duplicate_label_names"
+	// StreamLimit is a reason for discarding lines when we can't create a new stream
+	// because the limit of active streams has been reached.
+	StreamLimit Reason = "series_limit"
 
+	StreamLimitErrorMsg            = "Maximum active series limit exceeded (%d/%d), reduce the number of active streams (reduce labels or reduce label values), or contact your administrator to see if the limit can be increased"
 	MissingLabelsErrorMsg          = "error at least one label pair is required per profile"
 	InvalidLabelsErrorMsg          = "invalid labels '%s' with error: %s"
 	MaxLabelNamesPerSeriesErrorMsg = "profile series '%s' has %d label names; limit %d"
@@ -127,7 +132,7 @@ func ReasonOf(err error) Reason {
 	var validationErr *Error
 	ok := errors.As(err, &validationErr)
 	if !ok {
-		return "unknown"
+		return Unknown
 	}
 	return validationErr.Reason
 }

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -36,11 +36,11 @@ const (
 	LabelValueTooLong Reason = "label_value_too_long"
 	// DuplicateLabelNames is a reason for discarding a request which has duplicate label names
 	DuplicateLabelNames Reason = "duplicate_label_names"
-	// StreamLimit is a reason for discarding lines when we can't create a new stream
+	// SeriesLimit is a reason for discarding lines when we can't create a new stream
 	// because the limit of active streams has been reached.
-	StreamLimit Reason = "series_limit"
+	SeriesLimit Reason = "series_limit"
 
-	StreamLimitErrorMsg            = "Maximum active series limit exceeded (%d/%d), reduce the number of active streams (reduce labels or reduce label values), or contact your administrator to see if the limit can be increased"
+	SeriesLimitErrorMsg            = "Maximum active series limit exceeded (%d/%d), reduce the number of active streams (reduce labels or reduce label values), or contact your administrator to see if the limit can be increased"
 	MissingLabelsErrorMsg          = "error at least one label pair is required per profile"
 	InvalidLabelsErrorMsg          = "invalid labels '%s' with error: %s"
 	MaxLabelNamesPerSeriesErrorMsg = "profile series '%s' has %d label names; limit %d"


### PR DESCRIPTION
This bring ingester limits:
- Global & Local maximum of active series
- Out of orders.


This is intentionally tracked outside of the storage package to not account for reset when data is flushed.

Builds on #510 