### PR TITLE
Upgrade linter to work with Go Generics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,29 +65,20 @@ linters-settings:
 
 linters:
   enable:
-    - deadcode
     - errcheck
     - goconst
     - gofmt
     - goimports
     - revive
     - ineffassign
-    # - staticcheck
+    - staticcheck
     - misspell
-    - structcheck
     - unconvert
     - unparam
-    - varcheck
     - govet
-    # - unused
     - typecheck
     - depguard
     - exportloopref
-  # disable for now as they don't work with 1.18
-  disable:
-    - staticcheck
-    - unused
-    - gosimple
 
 issues:
   exclude:

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ $(BIN)/buf: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/gogo/protobuf v1.3.2
 	github.com/gogo/status v1.1.1
-	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/pprof v0.0.0-20221219190121-3cb0bae90811
 	github.com/google/uuid v1.3.0
@@ -145,6 +144,7 @@ require (
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -102,9 +102,7 @@ func (a *Agent) DroppedTargets() []*Target {
 
 	for _, tg := range a.groups {
 		tg.mtx.RLock()
-		for _, target := range tg.droppedTargets {
-			result = append(result, target)
-		}
+		result = append(result, tg.droppedTargets...)
 	}
 	return result
 }

--- a/pkg/agent/target.go
+++ b/pkg/agent/target.go
@@ -85,9 +85,7 @@ func (tg *TargetGroup) sync(groups []*targetgroup.Group) {
 				actives = append(actives, t)
 			}
 		}
-		for _, dt := range dropped {
-			tg.droppedTargets = append(tg.droppedTargets, dt)
-		}
+		tg.droppedTargets = append(tg.droppedTargets, dropped...)
 	}
 
 	for _, t := range actives {

--- a/pkg/ingester/clientpool/ingester_client_pool.go
+++ b/pkg/ingester/clientpool/ingester_client_pool.go
@@ -12,6 +12,7 @@ import (
 	ring_client "github.com/grafana/dskit/ring/client"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	ingestv1 "github.com/grafana/phlare/api/gen/proto/go/ingester/v1"
@@ -69,7 +70,7 @@ func NewPool(cfg PoolConfig, ring ring.ReadRing, factory ring_client.PoolFactory
 
 func PoolFactoryFn(options ...connect.ClientOption) ring_client.PoolFactory {
 	return func(addr string) (ring_client.PoolClient, error) {
-		conn, err := grpc.Dial(addr, grpc.WithInsecure())
+		conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -115,7 +115,7 @@ func (b *bucketWithPrefix) Upload(ctx context.Context, name string, r io.Reader)
 }
 
 func (b *bucketWithPrefix) Delete(ctx context.Context, name string) error {
-	return b.Delete(ctx, b.prefix(name))
+	return b.b.Delete(ctx, b.prefix(name))
 }
 
 func (b *bucketWithPrefix) Name() string {

--- a/pkg/parquet/group.go
+++ b/pkg/parquet/group.go
@@ -36,9 +36,7 @@ func (g Group) Leaf() bool { return false }
 
 func (g Group) Fields() []parquet.Field {
 	fields := make([]parquet.Field, len(g))
-	for pos := range g {
-		fields[pos] = g[pos]
-	}
+	copy(fields, g)
 	return fields
 }
 

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -410,7 +410,6 @@ func (f *Phlare) initUsageReport() (services.Service, error) {
 
 type statusService struct {
 	statusv1.UnimplementedStatusServiceServer
-	configYaml    string
 	defaultConfig *Config
 	actualConfig  *Config
 }

--- a/pkg/phlaredb/deduplicating_slice.go
+++ b/pkg/phlaredb/deduplicating_slice.go
@@ -142,7 +142,6 @@ func (s *deduplicatingSlice[M, K, H, P]) Flush(ctx context.Context) (numRows uin
 		// cap max row size by buffer
 		if rowsToFlush > s.cfg.MaxBufferRowCount {
 			rowsToFlush = s.cfg.MaxBufferRowCount
-
 		}
 
 		rows := make([]parquet.Row, rowsToFlush)
@@ -171,7 +170,7 @@ func (s *deduplicatingSlice[M, K, H, P]) Flush(ctx context.Context) (numRows uin
 	return uint64(rowsFlushed), uint64(rowGroupsFlushed), nil
 }
 
-func (s *deduplicatingSlice[M, K, H, P]) ingest(ctx context.Context, elems []M, rewriter *rewriter) error {
+func (s *deduplicatingSlice[M, K, H, P]) ingest(_ context.Context, elems []M, rewriter *rewriter) error {
 	var (
 		rewritingMap = make(map[int64]int64)
 		missing      = int64SlicePool.Get().([]int64)
@@ -220,17 +219,11 @@ func (s *deduplicatingSlice[M, K, H, P]) ingest(ctx context.Context, elems []M, 
 		s.lock.Unlock()
 	}
 
+	// nolint staticcheck
 	int64SlicePool.Put(missing[:0])
 
 	// add rewrite information to struct
 	s.helper.addToRewriter(rewriter, rewritingMap)
 
 	return nil
-}
-
-func (s *deduplicatingSlice[M, K, H, P]) getIndex(key K) (int64, bool) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	v, ok := s.lookup[key]
-	return v, ok
 }

--- a/pkg/phlaredb/functions.go
+++ b/pkg/phlaredb/functions.go
@@ -1,3 +1,4 @@
+// nolint unused
 package phlaredb
 
 import (
@@ -38,10 +39,11 @@ func (*functionsHelper) rewrite(r *rewriter, f *profilev1.Function) error {
 }
 
 func (*functionsHelper) setID(_, newID uint64, f *profilev1.Function) uint64 {
-	var oldID = f.Id
+	oldID := f.Id
 	f.Id = newID
 	return oldID
 }
+
 func (*functionsHelper) size(_ *profilev1.Function) uint64 {
 	return functionSize
 }

--- a/pkg/phlaredb/head.go
+++ b/pkg/phlaredb/head.go
@@ -46,6 +46,7 @@ func copySlice[T any](in []T) []T {
 
 type idConversionTable map[int64]int64
 
+// nolint unused
 func (t idConversionTable) rewrite(idx *int64) {
 	pos := *idx
 	var ok bool
@@ -55,6 +56,7 @@ func (t idConversionTable) rewrite(idx *int64) {
 	}
 }
 
+// nolint unused
 func (t idConversionTable) rewriteUint64(idx *uint64) {
 	pos := *idx
 	v, ok := t[int64(pos)]
@@ -76,9 +78,12 @@ func emptyRewriter() *rewriter {
 
 // rewriter contains slices to rewrite the per profile reference into per head references.
 type rewriter struct {
-	strings     stringConversionTable
-	functions   idConversionTable
-	mappings    idConversionTable
+	strings stringConversionTable
+	// nolint unused
+	functions idConversionTable
+	// nolint unused
+	mappings idConversionTable
+	// nolint unused
 	locations   idConversionTable
 	stacktraces idConversionTable
 }

--- a/pkg/phlaredb/locations.go
+++ b/pkg/phlaredb/locations.go
@@ -1,3 +1,4 @@
+// nolint unused
 package phlaredb
 
 import (

--- a/pkg/phlaredb/mappings.go
+++ b/pkg/phlaredb/mappings.go
@@ -1,3 +1,4 @@
+// nolint unused
 package phlaredb
 
 import (
@@ -40,6 +41,7 @@ func (*mappingsHelper) addToRewriter(r *rewriter, elemRewriter idConversionTable
 	r.mappings = elemRewriter
 }
 
+// nolint unparam
 func (*mappingsHelper) rewrite(r *rewriter, m *profilev1.Mapping) error {
 	r.strings.rewrite(&m.Filename)
 	r.strings.rewrite(&m.BuildId)
@@ -47,7 +49,7 @@ func (*mappingsHelper) rewrite(r *rewriter, m *profilev1.Mapping) error {
 }
 
 func (*mappingsHelper) setID(_, newID uint64, m *profilev1.Mapping) uint64 {
-	var oldID = m.Id
+	oldID := m.Id
 	m.Id = newID
 	return oldID
 }

--- a/pkg/phlaredb/phlaredb.go
+++ b/pkg/phlaredb/phlaredb.go
@@ -90,8 +90,6 @@ type PhlareDB struct {
 	volumeChecker diskutil.VolumeChecker
 	fs            fileSystem
 
-	headFlushTimer time.Timer
-
 	blockQuerier *BlockQuerier
 }
 
@@ -104,7 +102,7 @@ func New(phlarectx context.Context, cfg Config) (*PhlareDB, error) {
 	f := &PhlareDB{
 		cfg:    cfg,
 		logger: phlarecontext.Logger(phlarectx),
-		stopCh: make(chan struct{}, 0),
+		stopCh: make(chan struct{}),
 		volumeChecker: diskutil.NewVolumeChecker(
 			minFreeDisk,
 			minDiskAvailablePercentage,

--- a/pkg/phlaredb/phlaredb_test.go
+++ b/pkg/phlaredb/phlaredb_test.go
@@ -451,14 +451,8 @@ func TestFilterProfiles(t *testing.T) {
 	}, filtered)
 }
 
-type fakeBlock struct {
-	id   string
-	size uint64 // in mbytes
-}
-
 type fakeVolumeFS struct {
 	mock.Mock
-	blocks []fakeBlock
 }
 
 func (f *fakeVolumeFS) HasHighDiskUtilization(path string) (*diskutil.VolumeStats, error) {
@@ -470,6 +464,7 @@ func (f *fakeVolumeFS) Open(path string) (fs.File, error) {
 	args := f.Called(path)
 	return args[0].(fs.File), args.Error(1)
 }
+
 func (f *fakeVolumeFS) RemoveAll(path string) error {
 	args := f.Called(path)
 	return args.Error(0)

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -50,7 +50,7 @@ type profileStore struct {
 }
 
 func newProfileStore(phlarectx context.Context) *profileStore {
-	var s = &profileStore{
+	s := &profileStore{
 		logger:    phlarecontext.Logger(phlarectx),
 		metrics:   contextHeadMetrics(phlarectx),
 		persister: &schemav1.ProfilePersister{},
@@ -110,7 +110,6 @@ func (s *profileStore) Close() error {
 }
 
 func (s *profileStore) RowGroups() (rowGroups []parquet.RowGroup) {
-
 	rowGroups = make([]parquet.RowGroup, len(s.rowGroups))
 	for pos := range rowGroups {
 		rowGroups[pos] = s.rowGroups[pos]
@@ -139,7 +138,6 @@ func (s *profileStore) profileSort(i, j int) bool {
 
 	// finally use ID as tie breaker
 	return bytes.Compare(pI.ID[:], pJ.ID[:]) < 0
-
 }
 
 func (s *profileStore) Flush(ctx context.Context) (numRows uint64, numRowGroups uint64, err error) {
@@ -202,10 +200,7 @@ func (s *profileStore) prepareFile(path string) (closer io.Closer, err error) {
 func (s *profileStore) empty() bool {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	if len(s.slice) == 0 {
-		return true
-	}
-	return false
+	return len(s.slice) == 0
 }
 
 // cutRowGroups gets called, when a patrticular row group has been finished and it will flush it to disk. The caller of cutRowGroups should be holding the write lock.
@@ -368,7 +363,6 @@ func newRowGroupOnDisk(path string) (*rowGroupOnDisk, error) {
 	r.RowGroup = rowGroups[0]
 
 	return r, nil
-
 }
 
 func (r *rowGroupOnDisk) RowGroups() []parquet.RowGroup {
@@ -405,7 +399,6 @@ func (r *rowGroupOnDisk) columnIter(ctx context.Context, columnName string, pred
 		return query.NewErrIterator(fmt.Errorf("column '%s' not found in head row group segment '%s'", columnName, r.file.Name()))
 	}
 	return query.NewColumnIterator(ctx, []parquet.RowGroup{r.RowGroup}, column.ColumnIndex, columnName, 1000, predicate, alias)
-
 }
 
 type seriesIDRowsRewriter struct {
@@ -414,7 +407,7 @@ type seriesIDRowsRewriter struct {
 	seriesIndexes rowRangesWithSeriesIndex
 }
 
-func (r seriesIDRowsRewriter) SeekToRow(pos int64) error {
+func (r *seriesIDRowsRewriter) SeekToRow(pos int64) error {
 	if err := r.Rows.SeekToRow(pos); err != nil {
 		return err
 	}

--- a/pkg/phlaredb/profiles.go
+++ b/pkg/phlaredb/profiles.go
@@ -415,7 +415,7 @@ func (pi *profilesIndex) writeTo(ctx context.Context, path string) ([][]rowRange
 	rangesPerRG := make([][]rowRangeWithSeriesIndex, len(pfs[0].profilesOnDisk))
 
 	// Add series
-	//pi.seriesIndexes = make(map[model.Fingerprint]uint32, len(pfs))
+	// pi.seriesIndexes = make(map[model.Fingerprint]uint32, len(pfs))
 	for i, s := range pfs {
 		if err := writer.AddSeries(storage.SeriesRef(i), s.lbs, s.fp, index.ChunkMeta{
 			MinTime: s.minTime,
@@ -436,7 +436,7 @@ func (pi *profilesIndex) writeTo(ctx context.Context, path string) ([][]rowRange
 
 func (pl *profilesIndex) cutRowGroup(rgProfiles []*schemav1.Profile) error {
 	// adding rowGroup and rowNum information per fingerprint
-	var rowRangePerFP = make(map[model.Fingerprint]*rowRange, len(pl.profilesPerFP))
+	rowRangePerFP := make(map[model.Fingerprint]*rowRange, len(pl.profilesPerFP))
 	for rowNum, p := range rgProfiles {
 		if _, ok := rowRangePerFP[p.SeriesFingerprint]; !ok {
 			rowRangePerFP[p.SeriesFingerprint] = &rowRange{
@@ -463,7 +463,7 @@ func (pl *profilesIndex) cutRowGroup(rgProfiles []*schemav1.Profile) error {
 		ps.profiles = ps.profiles[:0]
 
 		// attach rowGroup and rowNum information
-		rowRange, _ := rowRangePerFP[ps.fp]
+		rowRange := rowRangePerFP[ps.fp]
 
 		ps.profilesOnDisk = append(
 			ps.profilesOnDisk,
@@ -472,7 +472,6 @@ func (pl *profilesIndex) cutRowGroup(rgProfiles []*schemav1.Profile) error {
 	}
 
 	return nil
-
 }
 
 // SplitFiltersAndMatchers splits empty matchers off, which are treated as filters, see #220
@@ -500,10 +499,12 @@ const (
 
 type profilesHelper struct{}
 
+// nolint unused
 func (*profilesHelper) addToRewriter(r *rewriter, elemRewriter idConversionTable) {
 	r.locations = elemRewriter
 }
 
+// nolint unused
 func (*profilesHelper) rewrite(r *rewriter, s *schemav1.Profile) error {
 	for pos := range s.Comments {
 		r.strings.rewrite(&s.Comments[pos])
@@ -515,14 +516,17 @@ func (*profilesHelper) rewrite(r *rewriter, s *schemav1.Profile) error {
 	return nil
 }
 
+// nolint unused
 func (*profilesHelper) setID(oldID, newID uint64, p *schemav1.Profile) uint64 {
 	return oldID
 }
 
+// nolint unused
 func sizeOfSample(s *schemav1.Sample) uint64 {
 	return sampleSize + 8
 }
 
+// nolint unused
 func (*profilesHelper) size(p *schemav1.Profile) uint64 {
 	size := profileSize
 
@@ -536,6 +540,7 @@ func (*profilesHelper) size(p *schemav1.Profile) uint64 {
 	return size
 }
 
+// nolint unused
 func (*profilesHelper) clone(p *schemav1.Profile) *schemav1.Profile {
 	return p
 }

--- a/pkg/phlaredb/sample_merge.go
+++ b/pkg/phlaredb/sample_merge.go
@@ -343,12 +343,6 @@ func (b *singleBlockQuerier) resolveSymbols(ctx context.Context, stacktraceAggrB
 	}, nil
 }
 
-func (b *singleBlockQuerier) sampleMerge() *sampleMerge {
-	return &sampleMerge{
-		profileSource: b.profiles.file,
-	}
-}
-
 func (b *singleBlockQuerier) MergeByLabels(ctx context.Context, rows iter.Iterator[Profile], by ...string) ([]*typesv1.Series, error) {
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "MergeByLabels - Block")
 	defer sp.Finish()
@@ -363,10 +357,6 @@ func (b *singleBlockQuerier) MergeByLabels(ctx context.Context, rows iter.Iterat
 type Source interface {
 	Schema() *parquet.Schema
 	RowGroups() []parquet.RowGroup
-}
-
-type sampleMerge struct {
-	profileSource Source
 }
 
 type profileSampleMap map[int64]*profile.Sample

--- a/pkg/phlaredb/stacktraces.go
+++ b/pkg/phlaredb/stacktraces.go
@@ -1,3 +1,4 @@
+// nolint unused
 package phlaredb
 
 import (

--- a/pkg/phlaredb/strings.go
+++ b/pkg/phlaredb/strings.go
@@ -1,3 +1,4 @@
+// nolint unused
 package phlaredb
 
 type stringConversionTable []int64
@@ -28,6 +29,7 @@ func (*stringsHelper) addToRewriter(r *rewriter, m idConversionTable) {
 	}
 }
 
+// nolint unused
 func (*stringsHelper) rewrite(*rewriter, string) error {
 	return nil
 }

--- a/pkg/phlaredb/tsdb/index.go
+++ b/pkg/phlaredb/tsdb/index.go
@@ -247,6 +247,7 @@ type indexValueEntry struct {
 type unlockIndex map[string]indexEntry
 
 // This is the prevalent value for Intel and AMD CPUs as-at 2018.
+// nolint unused
 const cacheLineSize = 64
 
 // Roughly
@@ -255,7 +256,7 @@ type indexShard struct {
 	shard uint32
 	mtx   sync.RWMutex
 	idx   unlockIndex
-	//nolint:structcheck,unused
+	//nolint structcheck,unused
 	pad [cacheLineSize - unsafe.Sizeof(sync.Mutex{}) - unsafe.Sizeof(unlockIndex{})]byte
 }
 

--- a/pkg/phlaredb/tsdb/index/postings.go
+++ b/pkg/phlaredb/tsdb/index/postings.go
@@ -480,6 +480,7 @@ func (it *intersectPostings) Err() error {
 	}
 	return nil
 }
+
 func (it *intersectPostings) Close() error {
 	for _, p := range it.arr {
 		if err := p.Close(); err != nil {
@@ -720,12 +721,6 @@ func (rp *removedPostings) Close() error {
 	}
 
 	return rp.remove.Close()
-}
-
-// ListPostings implements the Postings interface over a plain list.
-type ListPostings struct {
-	list []storage.SeriesRef
-	cur  storage.SeriesRef
 }
 
 // bigEndianPostings implements the Postings interface over a byte stream of

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -279,7 +279,7 @@ func (s *Statistics) Record(v float64) {
 		if min <= v {
 			break
 		}
-		if s.min.CAS(min, v) {
+		if s.min.CompareAndSwap(min, v) {
 			break
 		}
 	}
@@ -288,7 +288,7 @@ func (s *Statistics) Record(v float64) {
 		if max >= v {
 			break
 		}
-		if s.max.CAS(max, v) {
+		if s.max.CompareAndSwap(max, v) {
 			break
 		}
 	}
@@ -303,7 +303,7 @@ func (s *Statistics) Record(v float64) {
 		newMean := mean + (delta / float64(newCount))
 		newValue := value + (delta * (v - newMean))
 		newAvg := avg + ((v - avg) / float64(newCount))
-		if s.avg.CAS(avg, newAvg) && s.count.CAS(count, newCount) && s.mean.CAS(mean, newMean) && s.value.CAS(value, newValue) {
+		if s.avg.CompareAndSwap(avg, newAvg) && s.count.CompareAndSwap(count, newCount) && s.mean.CompareAndSwap(mean, newMean) && s.value.CompareAndSwap(value, newValue) {
 			break
 		}
 	}

--- a/pkg/util/httpgrpc/httpgrpc.go
+++ b/pkg/util/httpgrpc/httpgrpc.go
@@ -3,10 +3,11 @@ package httpgrpc
 import (
 	"fmt"
 
-	"github.com/golang/protobuf/ptypes"
 	log "github.com/sirupsen/logrus"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // Errorf returns a HTTP gRPC error than is correctly forwarded over
@@ -42,7 +43,7 @@ func HTTPResponseFromError(err error) (*HTTPResponse, bool) {
 	}
 
 	var resp HTTPResponse
-	if err := ptypes.UnmarshalAny(status.Details[0], &resp); err != nil {
+	if err := anypb.UnmarshalTo(status.Details[0], &resp, proto.UnmarshalOptions{}); err != nil {
 		log.Errorf("Got error containing non-response: %v", err)
 		return nil, false
 	}


### PR DESCRIPTION
Update the linter to finally work with Generics. This has surface small interesting issue but also a lot of false negative with `unused` and generics.

But at least now they all run correctly.