### PR TITLE
Bump minimal support version to 1.19

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,12 +3,12 @@
 
 # options for analysis running
 run:
-  go: "1.18"
+  go: "1.19"
   # default concurrency is a available CPU number
   concurrency: 16
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
+  timeout: 10m
 
   # exit code when at least one issue was found, default is 1
   issues-exit-code: 1

--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -19,7 +19,7 @@ a piece of work is finished it should:
 
 To be able to run make targets you'll need to install:
 
-- [Go](https://go.dev/doc/install) (> 1.18)
+- [Go](https://go.dev/doc/install) (> 1.19)
 - [Docker](https://docs.docker.com/engine/install/)
 
 All other required tools will be automatically downloaded `$(pwd)/.tmp/bin`.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/phlare
 
-go 1.18
+go 1.19
 
 require (
 	github.com/bufbuild/connect-go v1.4.1

--- a/pkg/agent/target.go
+++ b/pkg/agent/target.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -244,7 +243,7 @@ func (t *Target) fetchProfile(ctx context.Context, profileType string, buf io.Wr
 	}
 	defer resp.Body.Close()
 
-	b, err := ioutil.ReadAll(io.TeeReader(resp.Body, buf))
+	b, err := io.ReadAll(io.TeeReader(resp.Body, buf))
 	if err != nil {
 		return fmt.Errorf("failed to read body: %w", err)
 	}

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -2,7 +2,6 @@ package cfg
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -69,7 +68,7 @@ tls:
 
 func TestDefaultUnmarshal(t *testing.T) {
 	testContext := func(yamlString string, args []string) TestConfigWrapper {
-		file, err := ioutil.TempFile("", "config.yaml")
+		file, err := os.CreateTemp("", "config.yaml")
 		defer func() {
 			os.Remove(file.Name())
 		}()

--- a/pkg/cfg/dynamic_test.go
+++ b/pkg/cfg/dynamic_test.go
@@ -2,7 +2,7 @@ package cfg
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -21,7 +21,7 @@ server:
 		data := NewDynamicConfig(mockApplyDynamicConfig)
 		fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
 
-		file, err := ioutil.TempFile("", "config.yaml")
+		file, err := os.CreateTemp("", "config.yaml")
 		require.NoError(t, err)
 		_, err = file.WriteString(config)
 		require.NoError(t, err)

--- a/pkg/cfg/files.go
+++ b/pkg/cfg/files.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -20,7 +19,7 @@ func JSON(f *string) Source {
 			return nil
 		}
 
-		j, err := ioutil.ReadFile(*f)
+		j, err := os.ReadFile(*f)
 		if err != nil {
 			return err
 		}
@@ -42,7 +41,7 @@ func dJSON(y []byte) Source {
 // using https://pkg.go.dev/github.com/drone/envsubst?tab=overview
 func YAML(f string, expandEnvVars bool) Source {
 	return func(dst Cloneable) error {
-		y, err := ioutil.ReadFile(f)
+		y, err := os.ReadFile(f)
 		if err != nil {
 			return err
 		}

--- a/pkg/phlaredb/block/metadata.go
+++ b/pkg/phlaredb/block/metadata.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -229,7 +228,7 @@ func ReadFromDir(dir string) (*Meta, error) {
 }
 
 func exhaustCloseWithErrCapture(err *error, r io.ReadCloser, format string) {
-	_, copyErr := io.Copy(ioutil.Discard, r)
+	_, copyErr := io.Copy(io.Discard, r)
 
 	runutil.CloseWithErrCapture(err, r, format)
 

--- a/pkg/phlaredb/phlaredb_test.go
+++ b/pkg/phlaredb/phlaredb_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -38,7 +37,7 @@ import (
 func TestCreateLocalDir(t *testing.T) {
 	dataPath := t.TempDir()
 	localFile := dataPath + "/local"
-	require.NoError(t, ioutil.WriteFile(localFile, []byte("d"), 0o644))
+	require.NoError(t, os.WriteFile(localFile, []byte("d"), 0o644))
 	_, err := New(context.Background(), Config{
 		DataPath:         dataPath,
 		MaxBlockDuration: 30 * time.Minute,

--- a/pkg/phlaredb/shipper/shipper.go
+++ b/pkg/phlaredb/shipper/shipper.go
@@ -11,7 +11,6 @@ package shipper
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -369,7 +368,7 @@ func WriteMetaFile(logger log.Logger, dir string, meta *Meta) error {
 
 // ReadMetaFile reads the given meta from <dir>/shipper.json.
 func ReadMetaFile(dir string) (*Meta, error) {
-	b, err := ioutil.ReadFile(filepath.Join(dir, filepath.Clean(MetaFilename)))
+	b, err := os.ReadFile(filepath.Join(dir, filepath.Clean(MetaFilename)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/phlaredb/tsdb/index/index.go
+++ b/pkg/phlaredb/tsdb/index/index.go
@@ -22,7 +22,6 @@ import (
 	"hash"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -1194,7 +1193,7 @@ func (b RealByteSlice) Sub(start, end int) ByteSlice {
 // NewReader returns a new index reader on the given byte slice. It automatically
 // handles different format versions.
 func NewReader(b ByteSlice) (*Reader, error) {
-	return newReader(b, ioutil.NopCloser(nil))
+	return newReader(b, io.NopCloser(nil))
 }
 
 type nopCloser struct{}
@@ -1203,7 +1202,7 @@ func (nopCloser) Close() error { return nil }
 
 // NewFileReader returns a new index reader against the given index file.
 func NewFileReader(path string) (*Reader, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/phlaredb/tsdb/index/index_test.go
+++ b/pkg/phlaredb/tsdb/index/index_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"hash/crc32"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -520,7 +519,7 @@ func TestNewFileReaderErrorNoOpenFiles(t *testing.T) {
 	dir := testutil.NewTemporaryDirectory("block", t)
 
 	idxName := filepath.Join(dir.Path(), "index")
-	err := ioutil.WriteFile(idxName, []byte("corrupted contents"), 0o666)
+	err := os.WriteFile(idxName, []byte("corrupted contents"), 0o666)
 	require.NoError(t, err)
 
 	_, err = NewFileReader(idxName)

--- a/pkg/util/error_test.go
+++ b/pkg/util/error_test.go
@@ -3,7 +3,7 @@ package util
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -38,7 +38,7 @@ func Test_writeError(t *testing.T) {
 			rec := httptest.NewRecorder()
 			WriteError(tt.err, rec)
 			require.Equal(t, tt.expectedStatus, rec.Result().StatusCode)
-			b, err := ioutil.ReadAll(rec.Result().Body)
+			b, err := io.ReadAll(rec.Result().Body)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
1. Bump minimal support version to 1.19
If we use 1.18 to `make lint`, then we will get an error:
```sh
# honnef.co/go/tools/unused
../../go/pkg/mod/honnef.co/go/tools@v0.4.2/unused/unused.go:419:14: obj.Origin undefined (type *types.Var has no field or method Origin)
../../go/pkg/mod/honnef.co/go/tools@v0.4.2/unused/unused.go:421:14: obj.Origin undefined (type *types.Func has no field or method Origin)
note: module requires Go 1.19
# honnef.co/go/tools/staticcheck
../../go/pkg/mod/honnef.co/go/tools@v0.4.2/staticcheck/lint.go:4025:29: righti.Method(i).Origin undefined (type *types.Func has no field or method Origin)
../../go/pkg/mod/honnef.co/go/tools@v0.4.2/staticcheck/lint.go:4030:36: sel.Obj().(*types.Func).Origin undefined (type *types.Func has no field or method Origin)
note: module requires Go 1.19
```
2. Increase the timeout to 10m, because I found it failed twice.