### PR TITLE
Remove addresses on symbolized profiles

### DIFF
--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -344,6 +344,7 @@ var currentTime = time.Now
 //   - Removing empty samples.
 //   - Then remove unused references.
 //   - Ensure that the profile has a time_nanos set
+//   - Removes addresses from symbolized profiles.
 func (p *Profile) Normalize() {
 	// if the profile has no time, set it to now
 	if p.TimeNanos == 0 {
@@ -351,7 +352,7 @@ func (p *Profile) Normalize() {
 	}
 
 	p.ensureHasMapping()
-
+	p.clearAddresses()
 	// first we sort the samples location ids.
 	hashes := p.hasher.Hashes(p.Sample)
 
@@ -394,6 +395,22 @@ func (p *Profile) Normalize() {
 
 	// Remove references to removed samples.
 	p.clearSampleReferences(removedSamples)
+}
+
+// Removes addresses from symbolized profiles.
+func (p *Profile) clearAddresses() {
+	for _, m := range p.Mapping {
+		if m.HasFunctions {
+			m.MemoryLimit = 0
+			m.FileOffset = 0
+			m.MemoryStart = 0
+		}
+	}
+	for _, l := range p.Location {
+		if p.Mapping[l.MappingId-1].HasFunctions {
+			l.Address = 0
+		}
+	}
 }
 
 // ensureHasMapping ensures all locations have at least a mapping.

--- a/pkg/pprof/pprof_test.go
+++ b/pkg/pprof/pprof_test.go
@@ -33,12 +33,12 @@ func TestNormalizeProfile(t *testing.T) {
 			{LocationId: []uint64{1, 2, 3}, Value: []int64{0, 0}, Label: []*profilev1.Label{{Num: 10, Key: 1}}},
 			{LocationId: []uint64{4}, Value: []int64{0, 0}, Label: []*profilev1.Label{{Num: 10, Key: 1}}},
 		},
-		Mapping: []*profilev1.Mapping{},
+		Mapping: []*profilev1.Mapping{{Id: 1, HasFunctions: true, MemoryStart: 100, MemoryLimit: 200, FileOffset: 200}},
 		Location: []*profilev1.Location{
-			{Id: 1, Line: []*profilev1.Line{{FunctionId: 1, Line: 1}, {FunctionId: 2, Line: 3}}},
-			{Id: 2, Line: []*profilev1.Line{{FunctionId: 2, Line: 1}, {FunctionId: 3, Line: 3}}},
-			{Id: 3, Line: []*profilev1.Line{{FunctionId: 3, Line: 1}, {FunctionId: 4, Line: 3}}},
-			{Id: 4, Line: []*profilev1.Line{{FunctionId: 5, Line: 1}}},
+			{Id: 1, MappingId: 1, Address: 5, Line: []*profilev1.Line{{FunctionId: 1, Line: 1}, {FunctionId: 2, Line: 3}}},
+			{Id: 2, MappingId: 1, Address: 2, Line: []*profilev1.Line{{FunctionId: 2, Line: 1}, {FunctionId: 3, Line: 3}}},
+			{Id: 3, MappingId: 1, Address: 1, Line: []*profilev1.Line{{FunctionId: 3, Line: 1}, {FunctionId: 4, Line: 3}}},
+			{Id: 4, MappingId: 1, Address: 0, Line: []*profilev1.Line{{FunctionId: 5, Line: 1}}},
 		},
 		Function: []*profilev1.Function{
 			{Id: 1, Name: 5, SystemName: 6, Filename: 7, StartLine: 1},
@@ -71,8 +71,8 @@ func TestNormalizeProfile(t *testing.T) {
 			{LocationId: []uint64{2, 3}, Value: []int64{0, 1}, Label: []*profilev1.Label{}},
 		},
 		Mapping: []*profilev1.Mapping{{
-			Id:          1,
-			MemoryLimit: ^uint64(0),
+			Id:           1,
+			HasFunctions: true,
 		}},
 		Location: []*profilev1.Location{
 			{Id: 2, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 2, Line: 1}, {FunctionId: 3, Line: 3}}},


### PR DESCRIPTION
We realised that this create a lot of different stacktraces while just the address changes but not the binary itself. 

In the future we'll introduce buildid to recognized binary change, so when a profiles is symbolized we can just get rids on the adresses.