### PR TITLE
Mixin: Make the UID of the "Reads" and "Writes" Dashboards more unique

### DIFF
--- a/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/dashboards/phlare-reads.libsonnet
+++ b/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/dashboards/phlare-reads.libsonnet
@@ -28,7 +28,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                            querierSelector:: selector('querier'),
                            ingesterSelector:: selector('ingester'),
                          } +
-                         $.dashboard('Phlare / Reads', uid='reads')
+                         $.dashboard('Phlare / Reads', uid='phlare-reads')
                          .addCluster()
                          .addNamespace()
                          .addTag()

--- a/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/dashboards/phlare-writes.libsonnet
+++ b/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/dashboards/phlare-writes.libsonnet
@@ -31,7 +31,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                             distributorSelector:: selector('distributor'),
                             ingesterSelector:: selector('ingester'),
                           } +
-                          $.dashboard('Phlare / Writes', uid='writes')
+                          $.dashboard('Phlare / Writes', uid='phlare-writes')
                           .addCluster()
                           .addNamespace()
                           .addTag()


### PR DESCRIPTION
Related to #494 

Make the UID of the `Reads` and `Writes` Mixin Dashboards more unique by appending `phlare-` to them, e.g. `writes` becomes `phlare-writes`, this avoid conflicts with other Mixins (such as the Loki one).