### PR TITLE
refactor: cmd/phlare/main.go

### DIFF
--- a/cmd/phlare/main.go
+++ b/cmd/phlare/main.go
@@ -43,7 +43,13 @@ func (mf *mainFlags) RegisterFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&mf.PrintHelp, "help", false, "Print basic help.")
 	fs.BoolVar(&mf.PrintHelpAll, "help-all", false, "Print help, also including advanced and experimental parameters.")
 }
+func errorHandler(testMode bool) {
+	if testMode {
+		return
+	}
+	os.Exit(1)
 
+}
 func main() {
 	var (
 		flags mainFlags
@@ -53,19 +59,13 @@ func main() {
 
 	if err := cfg.DynamicUnmarshal(&flags, os.Args[1:], flag.CommandLine); err != nil {
 		fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
-		if testMode {
-			return
-		}
-		os.Exit(1)
+		errorHandler(testMode)
 	}
 
 	f, err := phlare.New(flags.Config)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed creating phlare: %v\n", err)
-		if testMode {
-			return
-		}
-		os.Exit(1)
+		errorHandler(testMode)
 	}
 
 	if flags.PrintVersion {
@@ -97,10 +97,7 @@ func main() {
 		flag.CommandLine.SetOutput(os.Stdout)
 		if err := usage.Usage(flags.PrintHelpAll, &flags); err != nil {
 			fmt.Fprintf(os.Stderr, "error printing usage: %s\n", err)
-			if testMode {
-				return
-			}
-			os.Exit(1)
+			errorHandler(testMode)
 		}
 
 		return
@@ -109,9 +106,6 @@ func main() {
 	err = f.Run()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed running phlare: %v\n", err)
-		if testMode {
-			return
-		}
-		os.Exit(1)
+		errorHandler(testMode)
 	}
 }


### PR DESCRIPTION
Given that identical segments of code are being employed in multiple instances, we can utilize the concept of functions, whereby the code is encapsulated within a named block that can be invoked at various points within the program.