### PR TITLE
Add the home page link for Phlare logo

### DIFF
--- a/pkg/api/index.gohtml
+++ b/pkg/api/index.gohtml
@@ -19,7 +19,9 @@
             <h1>Grafana Phlare Admin</h1>
         </div>
         <div class="col-12 col-sm-3 text-center text-sm-end mb-3 mb-sm-0">
+            <a href="{{AddPathPrefix "/"}}">
             <img alt="Phlare logo" class="phlare-brand" src="{{ AddPathPrefix "/static/phlare-logo.png" }}">
+            </a>
         </div>
     </div>
     {{ range $i, $ := .LinkGroups }}

--- a/pkg/api/index.gohtml
+++ b/pkg/api/index.gohtml
@@ -20,7 +20,7 @@
         </div>
         <div class="col-12 col-sm-3 text-center text-sm-end mb-3 mb-sm-0">
             <a href="{{AddPathPrefix "/"}}">
-            <img alt="Phlare logo" class="phlare-brand" src="{{ AddPathPrefix "/static/phlare-logo.png" }}">
+                 <img alt="Phlare logo" class="phlare-brand" src="{{ AddPathPrefix "/static/phlare-logo.png" }}">
             </a>
         </div>
     </div>

--- a/pkg/api/memberlist_status.gohtml
+++ b/pkg/api/memberlist_status.gohtml
@@ -21,7 +21,9 @@
                 <h1>Memberlist: Grafana Phlare</h1>
             </div>
             <div class="col-12 col-sm-3 text-center text-sm-end mb-3 mb-sm-0">
-                <img alt="Phlare logo" class="phlare-brand" src="{{ AddPathPrefix "/static/phlare-logo.png" }}">
+                <a href="{{AddPathPrefix "/"}}">
+                    <img alt="Phlare logo" class="phlare-brand" src="{{ AddPathPrefix "/static/phlare-logo.png" }}">
+                </a>
             </div>
         </div>
         <div class="row my-3">


### PR DESCRIPTION
Add a home page link for the Phlare logo. This would help us go back to the home page.
Also, it is quite common on other websites.
