### PR TITLE
Improve profiles flushing using ReadRowsFrom

### DIFF
--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -275,8 +275,13 @@ func (s *profileStore) writeRowGroups(path string, rowGroups []parquet.RowGroup)
 		if err != nil {
 			return 0, 0, err
 		}
+
 		n += uint64(nInt64)
 		numRowGroups += 1
+
+		if err := s.writer.Flush(); err != nil {
+			return 0, 0, err
+		}
 	}
 
 	if err := s.writer.Close(); err != nil {

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -271,7 +271,7 @@ func (s *profileStore) writeRowGroups(path string, rowGroups []parquet.RowGroup)
 	for rgN, rg := range rowGroups {
 		level.Debug(s.logger).Log("msg", "writing row group", "path", path, "row_group_number", rgN, "rows", rg.NumRows())
 
-		nInt64, err := s.writer.WriteRowGroup(rg)
+		nInt64, err := s.writer.ReadRowsFrom(rg.Rows())
 		if err != nil {
 			return 0, 0, err
 		}

--- a/pkg/phlaredb/profile_store_test.go
+++ b/pkg/phlaredb/profile_store_test.go
@@ -218,6 +218,40 @@ func TestProfileStore_Ingestion_SeriesIndexes(t *testing.T) {
 	}
 }
 
+func BenchmarkFlush(b *testing.B) {
+	b.StopTimer()
+	ctx := testContext(b)
+	metrics := newHeadMetrics(prometheus.NewRegistry())
+	rw := emptyRewriter()
+	b.ReportAllocs()
+	samples := make([]*schemav1.Sample, 10000)
+	for i := 0; i < 10000; i++ {
+		samples[i] = &schemav1.Sample{
+			Value:        int64(i),
+			StacktraceID: uint64(i),
+		}
+	}
+	for i := 0; i < b.N; i++ {
+
+		path := b.TempDir()
+		store := newProfileStore(ctx)
+		require.NoError(b, store.Init(path, defaultParquetConfig, metrics))
+		for rg := 0; rg < 10; rg++ {
+			for i := 0; i < 10^6; i++ {
+				p := threeProfileStreams(i)
+				p.p.Samples = samples
+				require.NoError(b, store.ingest(ctx, []*schemav1.Profile{&p.p}, p.lbls, p.profileName, rw))
+			}
+			require.NoError(b, store.cutRowGroup())
+		}
+		b.StartTimer()
+		// flush profiles and ensure the correct number of files are created
+		_, _, err := store.Flush(context.Background())
+		require.NoError(b, err)
+		b.StopTimer()
+	}
+}
+
 func ingestThreeProfileStreams(ctx context.Context, i int, ingest func(context.Context, *profilev1.Profile, uuid.UUID, ...*typesv1.LabelPair) error) error {
 	p := testhelper.NewProfileBuilder(time.Second.Nanoseconds() * int64(i))
 	p.CPUProfile()

--- a/pkg/phlaredb/profile_store_test.go
+++ b/pkg/phlaredb/profile_store_test.go
@@ -245,7 +245,6 @@ func BenchmarkFlush(b *testing.B) {
 			require.NoError(b, store.cutRowGroup())
 		}
 		b.StartTimer()
-		// flush profiles and ensure the correct number of files are created
 		_, _, err := store.Flush(context.Background())
 		require.NoError(b, err)
 		b.StopTimer()


### PR DESCRIPTION
This adds a flush benchmark and an optimization to reduce memory usage.

```
❯ benchstat before.txt after.txt                      
name      old time/op    new time/op    delta
Flush-16     400ms ± 8%     249ms ±10%  -37.76%  (p=0.008 n=5+5)

name      old alloc/op   new alloc/op   delta
Flush-16    1.03GB ± 0%    0.20GB ± 1%  -80.12%  (p=0.008 n=5+5)

name      old allocs/op  new allocs/op  delta
Flush-16     8.26k ± 1%     3.43k ± 1%  -58.54%  (p=0.008 n=5+5)
```