### PR TITLE
Allow environment variables from secrets/configMaps

### DIFF
--- a/operations/phlare/helm/phlare/templates/deployments-statefulsets.yaml
+++ b/operations/phlare/helm/phlare/templates/deployments-statefulsets.yaml
@@ -63,7 +63,11 @@ spec:
           env:
           {{- range $key, $value := . }}
             - name: {{ $key }}
+              {{- if kindIs "map" $value }}
+              {{- toYaml $value | nindent 14 }}
+              {{- else }}
               value: {{ $value | quote }}
+              {{- end }}
           {{- end }}
           {{- end }}
           {{- with $values.extraEnvFrom }}


### PR DESCRIPTION
This allows Helm values to be complex and hence specify
configMap/secrets as valueFrom soruces for environment variables.
