### PR TITLE
Fixes delta of samples computation

### DIFF
--- a/pkg/phlaredb/delta_test.go
+++ b/pkg/phlaredb/delta_test.go
@@ -93,7 +93,7 @@ func TestDeltaSample(t *testing.T) {
 		{StacktraceID: 2, Value: 1},
 		{StacktraceID: 3, Value: 1},
 	}
-	highest := deltaSamples([]*schemav1.Sample{}, new)
+	highest, _ := deltaSamples([]*schemav1.Sample{}, new)
 	require.Equal(t, 2, len(highest))
 	require.Equal(t, []*schemav1.Sample{
 		{StacktraceID: 2, Value: 1},
@@ -106,7 +106,7 @@ func TestDeltaSample(t *testing.T) {
 			{StacktraceID: 2, Value: 1},
 			{StacktraceID: 3, Value: 1},
 		}
-		highest = deltaSamples(highest, new)
+		highest, _ = deltaSamples(highest, new)
 		require.Equal(t, 2, len(highest))
 		require.Equal(t, []*schemav1.Sample{
 			{StacktraceID: 2, Value: 1},
@@ -123,7 +123,7 @@ func TestDeltaSample(t *testing.T) {
 			{StacktraceID: 2, Value: 1},
 			{StacktraceID: 3, Value: 1},
 		}
-		highest = deltaSamples(highest, new)
+		highest, _ = deltaSamples(highest, new)
 		require.Equal(t, 2, len(highest))
 		require.Equal(t, []*schemav1.Sample{
 			{StacktraceID: 2, Value: 1},
@@ -140,16 +140,12 @@ func TestDeltaSample(t *testing.T) {
 			{StacktraceID: 3, Value: 6},
 			{StacktraceID: 5, Value: 1},
 		}
-		highest = deltaSamples(highest, new)
+		highest, _ = deltaSamples(highest, new)
 		require.Equal(t, []*schemav1.Sample{
 			{StacktraceID: 2, Value: 1},
 			{StacktraceID: 3, Value: 6},
 			{StacktraceID: 5, Value: 1},
 		}, highest)
-		require.Equal(t, []*schemav1.Sample{
-			{StacktraceID: 3, Value: 5},
-			{StacktraceID: 5, Value: 1},
-		}, new)
 	})
 
 	t.Run("same stacktraces, counter samples resetting", func(t *testing.T) {
@@ -157,12 +153,9 @@ func TestDeltaSample(t *testing.T) {
 			{StacktraceID: 3, Value: 1},
 			{StacktraceID: 5, Value: 0},
 		}
-		highest = deltaSamples(highest, new)
-		require.Equal(t, []*schemav1.Sample{
-			{StacktraceID: 2, Value: 1},
-			{StacktraceID: 3, Value: 1},
-			{StacktraceID: 5, Value: 0},
-		}, highest)
+		highest, reset := deltaSamples(highest, new)
+		require.Nil(t, highest)
+		require.True(t, reset)
 		require.Equal(t, []*schemav1.Sample{
 			{StacktraceID: 3, Value: 1},
 			{StacktraceID: 5, Value: 0},
@@ -175,7 +168,7 @@ func TestDeltaSample(t *testing.T) {
 			{StacktraceID: 1, Value: 2},
 			{StacktraceID: 7, Value: 1},
 		}
-		highest = deltaSamples(highest, new)
+		highest, _ = deltaSamples(highest, new)
 		sort.Slice(highest, func(i, j int) bool {
 			return highest[i].StacktraceID < highest[j].StacktraceID
 		})
@@ -183,8 +176,8 @@ func TestDeltaSample(t *testing.T) {
 			{StacktraceID: 0, Value: 10},
 			{StacktraceID: 1, Value: 2},
 			{StacktraceID: 2, Value: 1},
-			{StacktraceID: 3, Value: 1},
-			{StacktraceID: 5, Value: 0},
+			{StacktraceID: 3, Value: 6},
+			{StacktraceID: 5, Value: 1},
 			{StacktraceID: 7, Value: 1},
 		}, highest)
 		require.Equal(t, []*schemav1.Sample{

--- a/pkg/phlaredb/head.go
+++ b/pkg/phlaredb/head.go
@@ -36,6 +36,7 @@ import (
 	phlarecontext "github.com/grafana/phlare/pkg/phlare/context"
 	"github.com/grafana/phlare/pkg/phlaredb/block"
 	schemav1 "github.com/grafana/phlare/pkg/phlaredb/schemas/v1"
+	"github.com/grafana/phlare/pkg/slices"
 )
 
 func copySlice[T any](in []T) []T {
@@ -348,10 +349,29 @@ func (h *Head) Ingest(ctx context.Context, p *profilev1.Profile, id uuid.UUID, e
 
 	var profileIngested bool
 	for idxType := range samplesPerType {
+		samples := samplesPerType[idxType]
+		sort.Slice(samples, func(i, j int) bool {
+			return samples[i].StacktraceID > samples[j].StacktraceID
+		})
+		total := len(samples)
+		samples = slices.RemoveInPlace(samples, func(s *schemav1.Sample, i int) bool {
+			if s.Value == 0 {
+				return true
+			}
+			if i < len(p.Sample)-1 && s.StacktraceID == samples[i+1].StacktraceID {
+				samples[i+1].Value += s.Value
+				return true
+			}
+			return false
+		})
+		if total != len(samples) {
+			// copy samples if there are less than received to avoid retaining memory.
+			samples = copySlice(samples)
+		}
 		profile := &schemav1.Profile{
 			ID:                id,
 			SeriesFingerprint: seriesFingerprints[idxType],
-			Samples:           samplesPerType[idxType],
+			Samples:           samples,
 			DropFrames:        p.DropFrames,
 			KeepFrames:        p.KeepFrames,
 			TimeNanos:         p.TimeNanos,
@@ -363,6 +383,7 @@ func (h *Head) Ingest(ctx context.Context, p *profilev1.Profile, id uuid.UUID, e
 		profile = h.delta.computeDelta(profile, labels[idxType])
 
 		if profile == nil {
+			level.Debug(h.logger).Log("msg", "profile is empty after delta computation", "metricName", metricName)
 			continue
 		}
 
@@ -371,6 +392,9 @@ func (h *Head) Ingest(ctx context.Context, p *profilev1.Profile, id uuid.UUID, e
 		}
 
 		profileIngested = true
+		h.totalSamples.Add(uint64(len(profile.Samples)))
+		h.metrics.sampleValuesIngested.WithLabelValues(metricName).Add(float64(len(profile.Samples)))
+		h.metrics.sampleValuesReceived.WithLabelValues(metricName).Add(float64(len(p.Sample)))
 	}
 
 	if !profileIngested {
@@ -386,11 +410,6 @@ func (h *Head) Ingest(ctx context.Context, p *profilev1.Profile, id uuid.UUID, e
 		h.meta.MaxTime = v
 	}
 	h.metaLock.Unlock()
-
-	samplesInProfile := len(samplesPerType[0]) * len(labels)
-	h.totalSamples.Add(sampleSize)
-	h.metrics.sampleValuesIngested.WithLabelValues(metricName).Add(float64(samplesInProfile))
-	h.metrics.sampleValuesReceived.WithLabelValues(metricName).Add(float64(len(p.Sample) * len(labels)))
 
 	return nil
 }

--- a/pkg/phlaredb/head.go
+++ b/pkg/phlaredb/head.go
@@ -350,6 +350,8 @@ func (h *Head) Ingest(ctx context.Context, p *profilev1.Profile, id uuid.UUID, e
 	var profileIngested bool
 	for idxType := range samplesPerType {
 		samples := samplesPerType[idxType]
+		// Sort samples per stacktraceID and aggregate duplicate stacktraceIDs into
+		// a single value to make sure we won't have any duplicates, as this is not recognized as part of the delta calculation.
 		sort.Slice(samples, func(i, j int) bool {
 			return samples[i].StacktraceID > samples[j].StacktraceID
 		})
@@ -360,6 +362,7 @@ func (h *Head) Ingest(ctx context.Context, p *profilev1.Profile, id uuid.UUID, e
 			}
 			if i < len(p.Sample)-1 && s.StacktraceID == samples[i+1].StacktraceID {
 				samples[i+1].Value += s.Value
+				// TODO: Currently we're not aggregating labels, and we should probably decide what to do with them in this case.
 				return true
 			}
 			return false

--- a/pkg/phlaredb/head_test.go
+++ b/pkg/phlaredb/head_test.go
@@ -274,7 +274,7 @@ func TestHeadIngestStacktraces(t *testing.T) {
 		}
 	}
 	// expect 4 samples, 3 of which distinct
-	require.Equal(t, []uint64{0, 1, 2, 2}, samples)
+	require.Equal(t, []uint64{1, 0, 2, 2}, samples)
 }
 
 func TestHeadLabelValues(t *testing.T) {

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -254,6 +254,10 @@ func (s *profileStore) cutRowGroup() (err error) {
 
 	level.Debug(s.logger).Log("msg", "cut row group segment", "path", path, "numProfiles", n)
 
+	for i := range s.slice {
+		// don't retain profiles and samples in memory as re-slice.
+		s.slice[i] = nil
+	}
 	// reset slice and metrics
 	s.slice = s.slice[:0]
 	s.size.Store(0)

--- a/pkg/phlaredb/profiles.go
+++ b/pkg/phlaredb/profiles.go
@@ -492,6 +492,7 @@ func SplitFiltersAndMatchers(allMatchers []*labels.Matcher) (filters, matchers [
 	return
 }
 
+// nolint unused
 const (
 	profileSize = uint64(unsafe.Sizeof(schemav1.Profile{}))
 	sampleSize  = uint64(unsafe.Sizeof(schemav1.Sample{}))


### PR DESCRIPTION
This fixes the computation of delta profiles. We were assuming that only one sample per stacktraces is passed to the delta function.

However this wasn't true, after ingesting symbols we can endup with the same stacktraces in different samples.

This PR makes sure that before computing the samples we sanitize the input.

I've also included couple of fixes to avoid retaining the memory here and there and combine with correct delta this has drastically improve performance of ingester.


This is the result in a busy cluster.

![image](https://user-images.githubusercontent.com/1053421/227058313-4c5d4038-6c72-4f04-bcb2-440994cde705.png)
