### PR TITLE
Adopt ingester shuffle sharding from mimir

### DIFF
--- a/cmd/phlare/help-all.txt.tmpl
+++ b/cmd/phlare/help-all.txt.tmpl
@@ -35,6 +35,8 @@ Usage of ./phlare:
     	Per-tenant allowed ingestion burst size (in sample size). Units in MB. The burst size refers to the per-distributor local rate limiter, and should be set at least to the maximum profile size expected in a single push request. (default 2)
   -distributor.ingestion-rate-limit-mb float
     	Per-tenant ingestion rate limit in sample size per second. Units in MB. (default 4)
+  -distributor.ingestion-tenant-shard-size int
+    	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
   -distributor.push.timeout duration
     	Timeout when pushing data to ingester. (default 5s)
   -distributor.replication-factor int

--- a/cmd/phlare/help.txt.tmpl
+++ b/cmd/phlare/help.txt.tmpl
@@ -21,6 +21,8 @@ Usage of ./phlare:
     	Per-tenant allowed ingestion burst size (in sample size). Units in MB. The burst size refers to the per-distributor local rate limiter, and should be set at least to the maximum profile size expected in a single push request. (default 2)
   -distributor.ingestion-rate-limit-mb float
     	Per-tenant ingestion rate limit in sample size per second. Units in MB. (default 4)
+  -distributor.ingestion-tenant-shard-size int
+    	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
   -distributor.push.timeout duration
     	Timeout when pushing data to ingester. (default 5s)
   -distributor.replication-factor int

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -99,9 +99,10 @@ type Distributor struct {
 type Limits interface {
 	IngestionRateBytes(tenantID string) float64
 	IngestionBurstSizeBytes(tenantID string) int
-	MaxLabelNameLength(userID string) int
-	MaxLabelValueLength(userID string) int
-	MaxLabelNamesPerSeries(userID string) int
+	IngestionTenantShardSize(tenantID string) int
+	MaxLabelNameLength(tenantID string) int
+	MaxLabelValueLength(tenantID string) int
+	MaxLabelNamesPerSeries(tenantID string) int
 }
 
 func New(cfg Config, ingestersRing ring.ReadRing, factory ring_client.PoolFactory, limits Limits, reg prometheus.Registerer, logger log.Logger, clientsOptions ...connect.ClientOption) (*Distributor, error) {
@@ -248,7 +249,10 @@ func (d *Distributor) Push(ctx context.Context, req *connect.Request[pushv1.Push
 	samplesByIngester := map[string][]*profileTracker{}
 	ingesterDescs := map[string]ring.InstanceDesc{}
 	for i, key := range keys {
-		replicationSet, err := d.ingestersRing.Get(key, ring.Write, descs[:0], nil, nil)
+		// Get a subring if tenant has shuffle shard size configured.
+		subRing := d.ingestersRing.ShuffleShard(tenantID, d.limits.IngestionTenantShardSize(tenantID))
+
+		replicationSet, err := subRing.Get(key, ring.Write, descs[:0], nil, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"runtime/pprof"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -282,4 +283,130 @@ func newOverrides(t *testing.T) *validation.Overrides {
 		l.MaxLabelNameLength = 10
 		tenantLimits["user-1"] = l
 	})
+}
+
+// this is a valid but pretty empty cpu pprof
+func emptyCPUPprof() []byte {
+	return []byte{0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xe2, 0x62, 0xe1, 0x60, 0x14, 0x60, 0xe2, 0x62, 0xe1, 0x60, 0x16, 0x60, 0xe1, 0x62, 0xe1, 0x60, 0x5, 0xb3, 0xd9, 0x4, 0x58, 0xa4, 0x4, 0x38, 0x18, 0x5, 0x1a, 0x1a, 0x1a, 0x98, 0x24, 0x1a, 0x1a, 0x76, 0xb, 0x69, 0xb0, 0x5b, 0x30, 0x1a, 0x31, 0x18, 0xf1, 0x26, 0xe6, 0xe4, 0xe4, 0x27, 0xc7, 0xe7, 0x27, 0x65, 0xa5, 0x26, 0x97, 0x14, 0x1b, 0xb1, 0x26, 0xe7, 0x97, 0xe6, 0x95, 0x18, 0x71, 0x43, 0x44, 0x8b, 0xb, 0x12, 0x93, 0x53, 0x8d, 0x58, 0x93, 0x2a, 0x4b, 0x52, 0x8b, 0x8d, 0x78, 0x33, 0xf3, 0x4a, 0x8b, 0x53, 0xe1, 0x2a, 0xb9, 0x21, 0x5c, 0x88, 0x12, 0x49, 0xfd, 0xd2, 0xe2, 0x22, 0xfd, 0x9c, 0xfc, 0xe4, 0xc4, 0x1c, 0xfd, 0xa4, 0xcc, 0x3c, 0xfd, 0x82, 0xa2, 0xfc, 0xdc, 0xd4, 0x92, 0x8c, 0xd4, 0xd2, 0x62, 0x23, 0x56, 0xb0, 0xa, 0x8f, 0x5f, 0x67, 0x3f, 0xfd, 0x9a, 0x73, 0xef, 0xfa, 0x4a, 0xf1, 0x80, 0x93, 0xad, 0x3d, 0x4f, 0x58, 0xa2, 0x58, 0x38, 0x38, 0x4, 0x58, 0x12, 0x1a, 0x1a, 0x14, 0x0, 0x1, 0x0, 0x0, 0xff, 0xff, 0x55, 0xb6, 0xc2, 0xa9, 0xae, 0x0, 0x0, 0x0}
+}
+
+func TestPush_ShuffleSharding(t *testing.T) {
+	// initialize 10 fake ingesters
+	var (
+		ingesters = map[string]*fakeIngester{}
+		ringDesc  = make([]ring.InstanceDesc, 10)
+	)
+	for pos := range ringDesc {
+		ingesters[strconv.Itoa(pos)] = newFakeIngester(t, false)
+		ringDesc[pos] = ring.InstanceDesc{
+			Addr: strconv.Itoa(pos),
+		}
+	}
+
+	overrides := validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+		// 3 shards by default
+		defaults.IngestionTenantShardSize = 3
+
+		// user with sharding disabled
+		user6 := validation.MockDefaultLimits()
+		user6.IngestionTenantShardSize = 0
+		tenantLimits["user-6"] = user6
+
+		// user with only 1 shard (less than replication factor)
+		user7 := validation.MockDefaultLimits()
+		user7.IngestionTenantShardSize = 1
+		tenantLimits["user-7"] = user7
+
+		// user with 9 shards
+		user8 := validation.MockDefaultLimits()
+		user8.IngestionTenantShardSize = 9
+		tenantLimits["user-8"] = user8
+
+		// user with 27 shards (more shards than ingesters)
+		user9 := validation.MockDefaultLimits()
+		user9.IngestionTenantShardSize = 27
+		tenantLimits["user-9"] = user9
+	})
+
+	// get distributor ready
+	d, err := New(Config{DistributorRing: ringConfig}, testhelper.NewMockRing(ringDesc, 3),
+		func(addr string) (client.PoolClient, error) {
+			return ingesters[addr], nil
+		},
+		overrides,
+		nil,
+		log.NewLogfmtLogger(os.Stdout),
+	)
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	mux.Handle(pushv1connect.NewPusherServiceHandler(d, connect.WithInterceptors(tenant.NewAuthInterceptor(true))))
+	s := httptest.NewServer(mux)
+	defer s.Close()
+
+	client := pushv1connect.NewPusherServiceClient(http.DefaultClient, s.URL, connect.WithInterceptors(tenant.NewAuthInterceptor(true)))
+
+	for i := 0; i < 10; i++ {
+		tenantID := fmt.Sprintf("user-%d", i)
+
+		// push 50 series each
+		for j := 0; j < 50; j++ {
+			_, err = client.Push(tenant.InjectTenantID(context.Background(), tenantID), connect.NewRequest(&pushv1.PushRequest{
+				Series: []*pushv1.RawProfileSeries{
+					{
+						Labels: []*typesv1.LabelPair{
+							{Name: "pod", Value: fmt.Sprintf("my-stateful-stuff-%d", j)},
+							{Name: "cluster", Value: "us-central1"},
+							{Name: "tenant", Value: tenantID},
+							{Name: "__name__", Value: "cpu"},
+						},
+						Samples: []*pushv1.RawSample{
+							{ID: "0000000-0000-0000-0000-000000000001", RawProfile: emptyCPUPprof()},
+						},
+					},
+				},
+			}))
+			require.NoError(t, err)
+		}
+	}
+
+	ingestersByTenantID := make(map[string]map[string]int)
+
+	// now let's check tenants per ingester
+	for ingID, ing := range ingesters {
+		ing.mtx.Lock()
+		for _, req := range ing.requests {
+			for _, s := range req.Series {
+				for _, l := range s.Labels {
+					if l.Name == "tenant" {
+						m := ingestersByTenantID[l.Value]
+						if m == nil {
+							m = make(map[string]int)
+							ingestersByTenantID[l.Value] = m
+						}
+						m[ingID]++
+					}
+				}
+			}
+		}
+		ing.mtx.Unlock()
+	}
+
+	for tenantID, ingesters := range ingestersByTenantID {
+		switch tenantID {
+		case "user-6", "user-9": // users with disabled sharding and higher than ingester count should have all ingesters
+			require.Equal(t, 10, len(ingesters))
+		case "user-8": // user 8 has 9 configured
+			require.Equal(t, 9, len(ingesters))
+		default: // everyone else should fall back to 3, which is the replication factor
+			require.Equal(t, 3, len(ingesters))
+
+			var series int
+			for _, count := range ingesters {
+				series += count
+			}
+			require.Equal(t, 150, series)
+		}
+	}
+
 }

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -178,10 +178,10 @@ func (l *limiter) convertGlobalToLocalLimit(tenantID string, globalLimit int) in
 	// (global limit / number of ingesters) * replication factor
 	numIngesters := l.ring.HealthyInstancesCount()
 
-	// May happen because the number of ingesters is asynchronously updated.
+	// No healthy ingester may happen because the number of ingesters is asynchronously updated.
 	// If happens, we just temporarily ignore the global limit.
-	if numIngesters > 0 {
-		return int((float64(globalLimit) / float64(numIngesters)) * float64(l.replicationFactor))
+	if numIngesters == 0 {
+		return 0
 	}
 
 	// If the number of available ingesters is greater than the tenant's shard

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/samber/lo"
 
 	phlaremodel "github.com/grafana/phlare/pkg/model"
+	"github.com/grafana/phlare/pkg/util"
 	"github.com/grafana/phlare/pkg/validation"
 )
 
@@ -23,6 +25,7 @@ type RingCount interface {
 type Limits interface {
 	MaxLocalSeriesPerTenant(tenantID string) int
 	MaxGlobalSeriesPerTenant(tenantID string) int
+	IngestionTenantShardSize(tenantID string) int
 }
 
 type Limiter interface {
@@ -147,7 +150,7 @@ func (l *limiter) assertMaxSeriesPerUser(tenantID string, series int) error {
 	// We can assume that series are evenly distributed across ingesters
 	// so we do convert the global limit into a local limit
 	globalLimit := l.limits.MaxGlobalSeriesPerTenant(tenantID)
-	adjustedGlobalLimit := convertGlobalToLocalLimit(globalLimit, l.ring, l.replicationFactor)
+	adjustedGlobalLimit := l.convertGlobalToLocalLimit(tenantID, globalLimit)
 
 	// Set the calculated limit to the lesser of the local limit or the new calculated global limit
 	calculatedLimit := minNonZero(localLimit, adjustedGlobalLimit)
@@ -164,7 +167,7 @@ func (l *limiter) assertMaxSeriesPerUser(tenantID string, series int) error {
 	return validation.NewErrorf(validation.SeriesLimit, validation.SeriesLimitErrorMsg, series, calculatedLimit)
 }
 
-func convertGlobalToLocalLimit(globalLimit int, ringCount RingCount, replicationFactor int) int {
+func (l *limiter) convertGlobalToLocalLimit(tenantID string, globalLimit int) int {
 	if globalLimit == 0 {
 		return 0
 	}
@@ -173,15 +176,23 @@ func convertGlobalToLocalLimit(globalLimit int, ringCount RingCount, replication
 	// topology changes) and we prefer to always be in favor of the tenant,
 	// we can use a per-ingester limit equal to:
 	// (global limit / number of ingesters) * replication factor
-	numIngesters := ringCount.HealthyInstancesCount()
+	numIngesters := l.ring.HealthyInstancesCount()
 
 	// May happen because the number of ingesters is asynchronously updated.
 	// If happens, we just temporarily ignore the global limit.
 	if numIngesters > 0 {
-		return int((float64(globalLimit) / float64(numIngesters)) * float64(replicationFactor))
+		return int((float64(globalLimit) / float64(numIngesters)) * float64(l.replicationFactor))
 	}
 
-	return 0
+	// If the number of available ingesters is greater than the tenant's shard
+	// size, then we should honor the shard size because series/metadata won't
+	// be written to more ingesters than it.
+	if shardSize := l.limits.IngestionTenantShardSize(tenantID); shardSize > 0 {
+		// We use Min() to protect from the case the expected shard size is > available ingesters.
+		numIngesters = lo.Min([]int{numIngesters, util.ShuffleShardExpectedInstances(shardSize, 1)})
+	}
+
+	return int((float64(globalLimit) / float64(numIngesters)) * float64(l.replicationFactor))
 }
 
 func minNonZero(first, second int) int {

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -2,10 +2,12 @@ package ingester
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	phlaremodel "github.com/grafana/phlare/pkg/model"
@@ -80,18 +82,52 @@ func TestGlobalMaxSeries(t *testing.T) {
 	}
 }
 
-func TestLocalLimit(t *testing.T) {
-	activeSeriesTimeout = 200 * time.Millisecond
-	activeSeriesCleanup = 100 * time.Millisecond
+func assertMaxSeries(t testing.TB, limiter Limiter, count int) {
+	var (
+		i   int
+		err error
+	)
+	for i = 1; i < count+1; i++ {
+		err = limiter.AllowProfile(model.Fingerprint(i), phlaremodel.LabelsFromStrings("i", strconv.Itoa(i)), 0)
+		require.NoError(t, err, "series %d should be allowed", i)
+	}
 
-	limiter := NewLimiter("foo", &fakeLimits{maxGlobalSeriesPerTenant: 5, maxLocalSeriesPerTenant: 1}, &fakeRingCount{2}, 3)
-	defer limiter.Stop()
-
-	// local limit of 1 series should take precedence over global limit of 5 series.
-
-	err := limiter.AllowProfile(1, phlaremodel.LabelsFromStrings("i", "1"), 0)
-	require.NoError(t, err)
-
-	err = limiter.AllowProfile(2, phlaremodel.LabelsFromStrings("i", "2"), 0)
+	i += 1
+	err = limiter.AllowProfile(model.Fingerprint(i), phlaremodel.LabelsFromStrings("i", strconv.Itoa(i)), 0)
 	require.Error(t, err)
+	assert.ErrorContains(t, err, "Maximum active series limit exceeded")
+}
+
+func TestLocalLimit(t *testing.T) {
+	t.Run("local limit", func(t *testing.T) {
+		limiter := NewLimiter("foo", &fakeLimits{maxGlobalSeriesPerTenant: 5, maxLocalSeriesPerTenant: 1}, &fakeRingCount{5}, 3)
+		defer limiter.Stop()
+
+		// local limit of 1 series should take precedence over global limit of 5 series.
+		assertMaxSeries(t, limiter, 1)
+	})
+
+	t.Run("local limit enforced by diving global limit", func(t *testing.T) {
+		limiter := NewLimiter("foo", &fakeLimits{maxGlobalSeriesPerTenant: 3}, &fakeRingCount{9}, 3)
+		defer limiter.Stop()
+
+		// local limit of 1 should be per ingester (globalLimit * replicationFactor) / ingesterNum
+		assertMaxSeries(t, limiter, 1)
+	})
+
+	t.Run("ensure we do not panic with zero ingesters", func(t *testing.T) {
+		limiter := NewLimiter("foo", &fakeLimits{maxGlobalSeriesPerTenant: 3}, &fakeRingCount{0}, 3)
+		defer limiter.Stop()
+
+		// we can ingest as many series as we want
+		require.NoError(t, limiter.AllowProfile(1, phlaremodel.LabelsFromStrings("i", "1"), 0))
+	})
+
+	t.Run("ensure we handle sharding correctly", func(t *testing.T) {
+		limiter := NewLimiter("foo", &fakeLimits{maxGlobalSeriesPerTenant: 3, ingestionTenantShardSize: 3}, &fakeRingCount{9}, 3)
+		defer limiter.Stop()
+
+		// local limit of 3 should be per ingester (globalLimit * replicationFactor) / shardSize
+		assertMaxSeries(t, limiter, 3)
+	})
 }

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -14,6 +14,7 @@ import (
 type fakeLimits struct {
 	maxLocalSeriesPerTenant  int
 	maxGlobalSeriesPerTenant int
+	ingestionTenantShardSize int
 }
 
 func (f *fakeLimits) MaxLocalSeriesPerTenant(userID string) int {
@@ -22,6 +23,10 @@ func (f *fakeLimits) MaxLocalSeriesPerTenant(userID string) int {
 
 func (f *fakeLimits) MaxGlobalSeriesPerTenant(userID string) int {
 	return f.maxGlobalSeriesPerTenant
+}
+
+func (f *fakeLimits) IngestionTenantShardSize(userID string) int {
+	return f.ingestionTenantShardSize
 }
 
 type fakeRingCount struct {

--- a/pkg/testhelper/ring.go
+++ b/pkg/testhelper/ring.go
@@ -69,6 +69,10 @@ func (r MockRing) ShuffleShard(identifier string, size int) ring.ReadRing {
 		return r
 	}
 
+	if rf := int(r.replicationFactor); size < rf {
+		size = rf
+	}
+
 	return &MockRing{
 		ingesters:         r.ingesters[:size],
 		replicationFactor: r.replicationFactor,

--- a/pkg/testhelper/ring.go
+++ b/pkg/testhelper/ring.go
@@ -64,9 +64,15 @@ func (r MockRing) HasInstance(instanceID string) bool {
 }
 
 func (r MockRing) ShuffleShard(identifier string, size int) ring.ReadRing {
-	// take advantage of pass by value to bound to size:
-	r.ingesters = r.ingesters[:size]
-	return r
+	// Nothing to do if the shard size is not smaller then the actual ring.
+	if size <= 0 || r.InstancesCount() <= size {
+		return r
+	}
+
+	return &MockRing{
+		ingesters:         r.ingesters[:size],
+		replicationFactor: r.replicationFactor,
+	}
 }
 
 func (r MockRing) ShuffleShardWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) ring.ReadRing {


### PR DESCRIPTION
This adds shuffle sharding for the write path. 

It will allow to configure the amount of shards of the whole ingester set that will be available to particular tenants.