### PR TITLE
Improve memory ownership at pprof parsing

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -210,6 +210,7 @@ func (d *Distributor) Push(ctx context.Context, req *connect.Request[pushv1.Push
 			// zip the data back into the buffer
 			bw := bytes.NewBuffer(raw.RawProfile[:0])
 			if _, err := p.WriteTo(bw); err != nil {
+				p.Close()
 				return nil, err
 			}
 			p.Close()

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 
+	profilev1 "github.com/grafana/phlare/api/gen/proto/go/google/v1"
 	ingesterv1 "github.com/grafana/phlare/api/gen/proto/go/ingester/v1"
 	pushv1 "github.com/grafana/phlare/api/gen/proto/go/push/v1"
 	phlareobjstore "github.com/grafana/phlare/pkg/objstore"
@@ -188,29 +189,28 @@ func (i *Ingester) Push(ctx context.Context, req *connect.Request[pushv1.PushReq
 		level.Debug(instance.logger).Log("msg", "message received by ingester push")
 		for _, series := range req.Msg.Series {
 			for _, sample := range series.Samples {
-				p, size, err := pprof.FromBytes(sample.RawProfile)
-				if err != nil {
-					return nil, err
-				}
-				id, err := uuid.Parse(sample.ID)
-				if err != nil {
-					return nil, err
-				}
-				if err := instance.Head().Ingest(ctx, p, id, series.Labels...); err != nil {
-					reason := validation.ReasonOf(err)
-					if reason != validation.Unknown {
-						validation.DiscardedProfiles.WithLabelValues(string(reason), instance.tenantID).Add(float64(1))
-						validation.DiscardedBytes.WithLabelValues(string(reason), instance.tenantID).Add(float64(size))
-						switch validation.ReasonOf(err) {
+				err := pprof.FromBytes(sample.RawProfile, func(p *profilev1.Profile, size int) error {
+					id, err := uuid.Parse(sample.ID)
+					if err != nil {
+						return err
+					}
+					if err = instance.Head().Ingest(ctx, p, id, series.Labels...); err != nil {
+						switch reason := validation.ReasonOf(err); reason {
 						case validation.OutOfOrder:
-							return nil, connect.NewError(connect.CodeInvalidArgument, err)
+							return connect.NewError(connect.CodeInvalidArgument, err)
 						case validation.SeriesLimit:
-							return nil, connect.NewError(connect.CodeResourceExhausted, err)
+							return connect.NewError(connect.CodeResourceExhausted, err)
+						default:
+							validation.DiscardedProfiles.WithLabelValues(string(reason), instance.tenantID).Add(float64(1))
+							validation.DiscardedBytes.WithLabelValues(string(reason), instance.tenantID).Add(float64(size))
+							return err
 						}
 					}
+					return nil
+				})
+				if err != nil {
 					return nil, err
 				}
-				p.ReturnToVTPool()
 			}
 		}
 		return connect.NewResponse(&pushv1.PushResponse{}), nil


### PR DESCRIPTION
In some cases an object allocated from the pool is not returned back to the pool. The change is aimed at improving ownership of the objects allocated in pools at pprof parsing specifically, which affects both distributor and ingester services