### PR TITLE
Update alpine version to 3.17.3

### DIFF
--- a/cmd/phlare/Dockerfile
+++ b/cmd/phlare/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 RUN apk add --no-cache ca-certificates
 

--- a/cmd/phlare/debug.Dockerfile
+++ b/cmd/phlare/debug.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 RUN apk add --no-cache ca-certificates
 

--- a/tools/docker-compose/golang/Dockerfile
+++ b/tools/docker-compose/golang/Dockerfile
@@ -7,7 +7,7 @@ COPY main.go .
 COPY go.mod .
 RUN CGO_ENABLED=0 GOOS=linux go build
 
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 # Copy over the directory containing the compiled binary for the profiling.
 COPY --from=builder /app/golang /golang

--- a/tools/upgrade-alpine-version.sh
+++ b/tools/upgrade-alpine-version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+
+# search replace all dockefiles
+TARGET="*/*Dockerfile*"
+git ls-files "$TARGET" | xargs sed -i 's/alpine:[0-9\.]\+/alpine:'$1'/g'
+
+# add changes
+git add -u "$TARGET"
+git commit -m "Update alpine version to $1"


### PR DESCRIPTION
- Update alpine version to 3.17.3: Addresses some CVE in openssl (not likely affected by this ourselves)
- Add upgrade alpine version script
