### PR TITLE
Also register pyroscope query handlers at query-frontend

### DIFF
--- a/pkg/querier/grpc_handler.go
+++ b/pkg/querier/grpc_handler.go
@@ -1,40 +1,11 @@
 package querier
 
 import (
-	"context"
-	"net/http"
-
 	"github.com/grafana/phlare/api/gen/proto/go/querier/v1/querierv1connect"
 	"github.com/grafana/phlare/pkg/util/connectgrpc"
-	"github.com/grafana/phlare/pkg/util/httpgrpc"
 )
 
-// todo: this could be generated but first we need more operational experience in case we need to change it.
-type grpcHandler struct {
-	querierv1connect.QuerierServiceHandler
-}
-
 func NewGRPCHandler(svc querierv1connect.QuerierServiceHandler) connectgrpc.GRPCHandler {
-	return &grpcHandler{svc}
-}
-
-func (q *grpcHandler) Handle(ctx context.Context, req *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
-	switch req.Url {
-	case "/querier.v1.QuerierService/ProfileTypes":
-		return connectgrpc.HandleUnary(ctx, req, q.ProfileTypes)
-	case "/querier.v1.QuerierService/LabelValues":
-		return connectgrpc.HandleUnary(ctx, req, q.LabelValues)
-	case "/querier.v1.QuerierService/LabelNames":
-		return connectgrpc.HandleUnary(ctx, req, q.LabelNames)
-	case "/querier.v1.QuerierService/Series":
-		return connectgrpc.HandleUnary(ctx, req, q.Series)
-	case "/querier.v1.QuerierService/SelectMergeStacktraces":
-		return connectgrpc.HandleUnary(ctx, req, q.SelectMergeStacktraces)
-	case "/querier.v1.QuerierService/SelectMergeProfile":
-		return connectgrpc.HandleUnary(ctx, req, q.SelectMergeProfile)
-	case "/querier.v1.QuerierService/SelectSeries":
-		return connectgrpc.HandleUnary(ctx, req, q.SelectSeries)
-	default:
-		return nil, httpgrpc.Errorf(http.StatusNotFound, "url %s not found", req.Url)
-	}
+	_, h := querierv1connect.NewQuerierServiceHandler(svc)
+	return connectgrpc.NewHandler(h)
 }

--- a/pkg/querier/grpc_roundtripper.go
+++ b/pkg/querier/grpc_roundtripper.go
@@ -1,49 +1,16 @@
 package querier
 
 import (
-	"context"
-
 	"github.com/bufbuild/connect-go"
 
-	googlev1 "github.com/grafana/phlare/api/gen/proto/go/google/v1"
-	querierv1 "github.com/grafana/phlare/api/gen/proto/go/querier/v1"
 	"github.com/grafana/phlare/api/gen/proto/go/querier/v1/querierv1connect"
 	"github.com/grafana/phlare/pkg/util/connectgrpc"
 )
 
-// todo: this could be generated.
-type grpcRoundTripper struct {
-	connectgrpc.GRPCRoundTripper
-}
-
 func NewGRPCRoundTripper(transport connectgrpc.GRPCRoundTripper) querierv1connect.QuerierServiceHandler {
-	return &grpcRoundTripper{transport}
-}
-
-func (f *grpcRoundTripper) ProfileTypes(ctx context.Context, in *connect.Request[querierv1.ProfileTypesRequest]) (*connect.Response[querierv1.ProfileTypesResponse], error) {
-	return connectgrpc.RoundTripUnary[querierv1.ProfileTypesRequest, querierv1.ProfileTypesResponse](f, ctx, in)
-}
-
-func (f *grpcRoundTripper) LabelValues(ctx context.Context, in *connect.Request[querierv1.LabelValuesRequest]) (*connect.Response[querierv1.LabelValuesResponse], error) {
-	return connectgrpc.RoundTripUnary[querierv1.LabelValuesRequest, querierv1.LabelValuesResponse](f, ctx, in)
-}
-
-func (f *grpcRoundTripper) LabelNames(ctx context.Context, in *connect.Request[querierv1.LabelNamesRequest]) (*connect.Response[querierv1.LabelNamesResponse], error) {
-	return connectgrpc.RoundTripUnary[querierv1.LabelNamesRequest, querierv1.LabelNamesResponse](f, ctx, in)
-}
-
-func (f *grpcRoundTripper) Series(ctx context.Context, in *connect.Request[querierv1.SeriesRequest]) (*connect.Response[querierv1.SeriesResponse], error) {
-	return connectgrpc.RoundTripUnary[querierv1.SeriesRequest, querierv1.SeriesResponse](f, ctx, in)
-}
-
-func (f *grpcRoundTripper) SelectMergeStacktraces(ctx context.Context, in *connect.Request[querierv1.SelectMergeStacktracesRequest]) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
-	return connectgrpc.RoundTripUnary[querierv1.SelectMergeStacktracesRequest, querierv1.SelectMergeStacktracesResponse](f, ctx, in)
-}
-
-func (f *grpcRoundTripper) SelectMergeProfile(ctx context.Context, in *connect.Request[querierv1.SelectMergeProfileRequest]) (*connect.Response[googlev1.Profile], error) {
-	return connectgrpc.RoundTripUnary[querierv1.SelectMergeProfileRequest, googlev1.Profile](f, ctx, in)
-}
-
-func (f *grpcRoundTripper) SelectSeries(ctx context.Context, in *connect.Request[querierv1.SelectSeriesRequest]) (*connect.Response[querierv1.SelectSeriesResponse], error) {
-	return connectgrpc.RoundTripUnary[querierv1.SelectSeriesRequest, querierv1.SelectSeriesResponse](f, ctx, in)
+	return querierv1connect.NewQuerierServiceClient(
+		connectgrpc.NewClient(transport),
+		"http://httpgrpc",
+		connect.WithGRPCWeb(),
+	)
 }

--- a/pkg/util/connectgrpc/connectgrpc.go
+++ b/pkg/util/connectgrpc/connectgrpc.go
@@ -105,6 +105,9 @@ func decodeRequest[Req any](req *httpgrpc.HTTPRequest) (*connect.Request[Req], e
 }
 
 func encodeRequest[Req any](req *connect.Request[Req]) (*httpgrpc.HTTPRequest, error) {
+	if req.Spec().Procedure == "" {
+		return nil, errors.New("cannot encode a request with empty procedure")
+	}
 	out := &httpgrpc.HTTPRequest{
 		Method:  http.MethodPost,
 		Url:     req.Spec().Procedure,

--- a/pkg/util/connectgrpc/connectgrpc.go
+++ b/pkg/util/connectgrpc/connectgrpc.go
@@ -1,8 +1,11 @@
 package connectgrpc
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/bufbuild/connect-go"
@@ -29,7 +32,7 @@ func HandleUnary[Req any, Res any](ctx context.Context, req *httpgrpc.HTTPReques
 			return &httpgrpc.HTTPResponse{
 				Code:    CodeToHTTP(connectErr.Code()),
 				Body:    []byte(connectErr.Message()),
-				Headers: connectHeaderToHTTPHeader(connectErr.Meta()),
+				Headers: connectHeaderToHTTPGRPCHeader(connectErr.Meta()),
 			}, nil
 		}
 
@@ -71,7 +74,7 @@ func RoundTripUnary[Req any, Res any](rt GRPCRoundTripper, ctx context.Context, 
 
 func encodeResponse[Req any](resp *connect.Response[Req]) (*httpgrpc.HTTPResponse, error) {
 	out := &httpgrpc.HTTPResponse{
-		Headers: connectHeaderToHTTPHeader(resp.Header()),
+		Headers: connectHeaderToHTTPGRPCHeader(resp.Header()),
 		Code:    http.StatusOK,
 	}
 	var err error
@@ -82,13 +85,21 @@ func encodeResponse[Req any](resp *connect.Response[Req]) (*httpgrpc.HTTPRespons
 	return out, nil
 }
 
-func connectHeaderToHTTPHeader(header http.Header) []*httpgrpc.Header {
-	result := []*httpgrpc.Header{}
+func connectHeaderToHTTPGRPCHeader(header http.Header) []*httpgrpc.Header {
+	result := make([]*httpgrpc.Header, 0, len(header))
 	for k, v := range header {
 		result = append(result, &httpgrpc.Header{
 			Key:    k,
 			Values: v,
 		})
+	}
+	return result
+}
+
+func httpgrpcHeaderToConnectHeader(header []*httpgrpc.Header) http.Header {
+	result := make(http.Header, len(header))
+	for _, h := range header {
+		result[h.Key] = h.Values
 	}
 	return result
 }
@@ -111,11 +122,9 @@ func encodeRequest[Req any](req *connect.Request[Req]) (*httpgrpc.HTTPRequest, e
 	out := &httpgrpc.HTTPRequest{
 		Method:  http.MethodPost,
 		Url:     req.Spec().Procedure,
-		Headers: []*httpgrpc.Header{},
+		Headers: connectHeaderToHTTPGRPCHeader(req.Header()),
 	}
-	for k, v := range req.Header() {
-		out.Headers = append(out.Headers, &httpgrpc.Header{Key: k, Values: v})
-	}
+
 	var err error
 	msg := req.Any()
 	out.Body, err = proto.Marshal(msg.(proto.Message))
@@ -195,4 +204,88 @@ func HTTPToCode(httpCode int32) connect.Code {
 	default:
 		return connect.CodeUnknown
 	}
+}
+
+type responseWriter struct {
+	header http.Header
+	resp   httpgrpc.HTTPResponse
+}
+
+func (r *responseWriter) Header() http.Header {
+	return r.header
+}
+
+func (r *responseWriter) Write(data []byte) (int, error) {
+	r.resp.Body = append(r.resp.Body, data...)
+	return len(data), nil
+}
+
+func (r *responseWriter) WriteHeader(statusCode int) {
+	r.resp.Code = int32(statusCode)
+}
+
+func (r *responseWriter) HTTPResponse() *httpgrpc.HTTPResponse {
+	r.resp.Headers = connectHeaderToHTTPGRPCHeader(r.header)
+	return &r.resp
+}
+
+// NewHandler converts a Connect handler into a HTTPGRPC handler
+type grpcHandler struct {
+	next http.Handler
+}
+
+func NewHandler(h http.Handler) GRPCHandler {
+	return &grpcHandler{next: h}
+}
+
+func newResponseWriter() *responseWriter {
+	rw := &responseWriter{header: http.Header{}}
+	rw.resp.Code = 200
+	return rw
+}
+
+func (q *grpcHandler) Handle(ctx context.Context, req *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
+	stdReq, err := http.NewRequestWithContext(ctx, req.Method, req.Url, bytes.NewReader(req.Body))
+	if err != nil {
+		return nil, err
+	}
+	stdReq.Header = httpgrpcHeaderToConnectHeader(req.Headers)
+
+	rw := newResponseWriter()
+	q.next.ServeHTTP(rw, stdReq)
+
+	return rw.HTTPResponse(), nil
+}
+
+type httpgrpcClient struct {
+	transport GRPCRoundTripper
+}
+
+func NewClient(transport GRPCRoundTripper) connect.HTTPClient {
+	return &httpgrpcClient{transport: transport}
+}
+
+func (g *httpgrpcClient) Do(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := g.transport.RoundTripGRPC(req.Context(), &httpgrpc.HTTPRequest{
+		Url:     req.URL.String(),
+		Headers: connectHeaderToHTTPGRPCHeader(req.Header),
+		Method:  req.Method,
+		Body:    body,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("grpc roundtripper error: %w", err)
+	}
+
+	return &http.Response{
+		Body:          io.NopCloser(bytes.NewReader(resp.Body)),
+		ContentLength: int64(len(resp.Body)),
+		StatusCode:    int(resp.Code),
+		Header:        httpgrpcHeaderToConnectHeader(resp.Headers),
+	}, nil
+
 }


### PR DESCRIPTION
This will allow better query handling in micro-services mode.

As part of that I implemented wrapping of connect in HTTPGRPC by using the generated clients and handlers. (Avoids the static code that was required before).