### PR TITLE
fix(pyroscope): use nanos sample type units for cpu & wall profiles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -278,5 +278,6 @@ replace (
 	// merged upstream yet.
 	github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220708130638-bd88e10a3d91
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.41.0
+	github.com/pyroscope-io/pyroscope => ../../pyroscope/pyroscope
 	google.golang.org/grpc => google.golang.org/grpc v1.44.0
 )

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.39.0
 	github.com/prometheus/prometheus v1.99.0
-	github.com/pyroscope-io/pyroscope v0.37.3-0.20230328035933-35db4234452a
+	github.com/pyroscope-io/pyroscope v0.37.3-0.20230424172735-981d3aa1203f
 	github.com/samber/lo v1.37.0
 	github.com/segmentio/parquet-go v0.0.0-20221214174709-7a0ad59e0540
 	github.com/sirupsen/logrus v1.9.0
@@ -278,6 +278,5 @@ replace (
 	// merged upstream yet.
 	github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220708130638-bd88e10a3d91
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.41.0
-	github.com/pyroscope-io/pyroscope => ../../pyroscope/pyroscope
 	google.golang.org/grpc => google.golang.org/grpc v1.44.0
 )

--- a/go.sum
+++ b/go.sum
@@ -833,8 +833,6 @@ github.com/prometheus/prometheus v0.41.0/go.mod h1:Uu5817xm7ibU/VaDZ9pu1ssGzcpO9
 github.com/prometheus/statsd_exporter v0.15.0/go.mod h1:Dv8HnkoLQkeEjkIE4/2ndAA7WL1zHKK7WMqFQqu72rw=
 github.com/pyroscope-io/jfr-parser v0.6.0 h1:4cQqs+9edZMbZ1ogJ0XDGtgM+PoII4kybJOunVMeD9I=
 github.com/pyroscope-io/jfr-parser v0.6.0/go.mod h1:ZMcbJjfDkOwElEK8CvUJbpetztRWRXszCmf5WU0erV8=
-github.com/pyroscope-io/pyroscope v0.37.3-0.20230328035933-35db4234452a h1:PbppLKCTjK5dN3FeQxchCz5IJO+EqGmoS5AouzB7XWQ=
-github.com/pyroscope-io/pyroscope v0.37.3-0.20230328035933-35db4234452a/go.mod h1:BQfXcD5+jFB/B0jZRGmvyfn7+twVvC6syMBBpd8Pifk=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
 github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/go.sum
+++ b/go.sum
@@ -833,6 +833,8 @@ github.com/prometheus/prometheus v0.41.0/go.mod h1:Uu5817xm7ibU/VaDZ9pu1ssGzcpO9
 github.com/prometheus/statsd_exporter v0.15.0/go.mod h1:Dv8HnkoLQkeEjkIE4/2ndAA7WL1zHKK7WMqFQqu72rw=
 github.com/pyroscope-io/jfr-parser v0.6.0 h1:4cQqs+9edZMbZ1ogJ0XDGtgM+PoII4kybJOunVMeD9I=
 github.com/pyroscope-io/jfr-parser v0.6.0/go.mod h1:ZMcbJjfDkOwElEK8CvUJbpetztRWRXszCmf5WU0erV8=
+github.com/pyroscope-io/pyroscope v0.37.3-0.20230424172735-981d3aa1203f h1:BhFAmuGi5aOm+6Qx2mKCKSF6lc+gEgZKHYzC0xy/zQg=
+github.com/pyroscope-io/pyroscope v0.37.3-0.20230424172735-981d3aa1203f/go.mod h1:BQfXcD5+jFB/B0jZRGmvyfn7+twVvC6syMBBpd8Pifk=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
 github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
addresses https://github.com/grafana/pyroscope/issues/2070 and https://github.com/grafana/pyroscope/issues/2073
depends on https://github.com/grafana/pyroscope/pull/1927