### PR TITLE
fix: serve UI in prod mode

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -138,10 +138,15 @@ func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
 		return fmt.Errorf("unable to initialize the ui: %w", err)
 	}
 
+	uiIndexHandler, err := public.NewIndexHandler()
+	if err != nil {
+		return fmt.Errorf("unable to initialize the ui: %w", err)
+	}
+
 	// All assets are served as static files
 	a.RegisterRoutesWithPrefix("/ui/assets/", http.StripPrefix("/ui/", http.FileServer(uiAssets)), false, true, "GET")
 	// Serve index to all other pages
-	a.RegisterRoutesWithPrefix("/ui/", http.HandlerFunc(public.ServeIndex), false, true, "GET")
+	a.RegisterRoutesWithPrefix("/ui/", uiIndexHandler, false, true, "GET")
 
 	// register status service providing config and buildinfo at grpc gateway
 	if err := statusv1.RegisterStatusServiceHandlerServer(context.Background(), a.grpcGatewayMux, statusService); err != nil {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -137,7 +137,12 @@ func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
 	if err != nil {
 		return fmt.Errorf("unable to initialize the ui: %w", err)
 	}
-	a.RegisterRoutesWithPrefix("/ui/", http.StripPrefix("/ui/", http.FileServer(uiAssets)), false, true, "GET")
+
+	// All assets are served as static files
+	a.RegisterRoutesWithPrefix("/ui/assets/", http.StripPrefix("/ui/", http.FileServer(uiAssets)), false, true, "GET")
+	// Serve index to all other pages
+	a.RegisterRoutesWithPrefix("/ui/", http.HandlerFunc(public.ServeIndex), false, true, "GET")
+
 	// register status service providing config and buildinfo at grpc gateway
 	if err := statusv1.RegisterStatusServiceHandlerServer(context.Background(), a.grpcGatewayMux, statusService); err != nil {
 		return err

--- a/public/app/app.tsx
+++ b/public/app/app.tsx
@@ -7,7 +7,7 @@ import '@webapp/../sass/profile.scss';
 import '@szhsin/react-menu/dist/index.css';
 import Notifications from '@webapp/ui/Notifications';
 import { Router, Switch, Route } from 'react-router-dom';
-import history from '@webapp/util/history';
+import { createBrowserHistory } from 'history';
 
 import { SingleView } from './pages/SingleView';
 import { ComparisonView } from './pages/ComparisonView';
@@ -16,20 +16,28 @@ import { LoadAppNames } from './components/LoadAppNames';
 const container = document.getElementById('reactRoot') as HTMLElement;
 const root = ReactDOM.createRoot(container);
 
-root.render(
-  <Provider store={store}>
-    <Notifications />
-    <LoadAppNames>
-      <Router history={history}>
-        <Switch>
-          <Route exact path={'/'}>
-            <SingleView />
-          </Route>
-          <Route path={'/comparison'}>
-            <ComparisonView />
-          </Route>
-        </Switch>
-      </Router>
-    </LoadAppNames>
-  </Provider>
-);
+function App() {
+  // Defined statically in webpack when building
+  const basepath = process.env.BASEPATH ? process.env.BASEPATH : '';
+  const history = createBrowserHistory({ basename: basepath });
+
+  return (
+    <Provider store={store}>
+      <Notifications />
+      <LoadAppNames>
+        <Router history={history}>
+          <Switch>
+            <Route exact path={'/'}>
+              <SingleView />
+            </Route>
+            <Route path={'/comparison'}>
+              <ComparisonView />
+            </Route>
+          </Switch>
+        </Router>
+      </LoadAppNames>
+    </Provider>
+  );
+}
+
+root.render(<App />);

--- a/public/assets.go
+++ b/public/assets.go
@@ -13,6 +13,11 @@ func Assets() (http.FileSystem, error) {
 	return http.Dir("./public/build"), nil
 }
 
-func ServeIndex(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("This route is not available in dev mode."))
+func NewIndexHandler() (http.HandlerFunc, error) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("This route is not available in dev mode."))
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}, nil
 }

--- a/public/assets.go
+++ b/public/assets.go
@@ -17,7 +17,7 @@ func NewIndexHandler() (http.HandlerFunc, error) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("This route is not available in dev mode."))
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}, nil
 }

--- a/public/assets.go
+++ b/public/assets.go
@@ -12,3 +12,7 @@ var AssetsEmbedded = false
 func Assets() (http.FileSystem, error) {
 	return http.Dir("./public/build"), nil
 }
+
+func ServeIndex(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("This route is not available in dev mode."))
+}

--- a/public/assets_embedded.go
+++ b/public/assets_embedded.go
@@ -5,7 +5,6 @@ package public
 
 import (
 	"embed"
-	"fmt"
 	"io/fs"
 	"net/http"
 	"path/filepath"
@@ -26,14 +25,17 @@ func Assets() (http.FileSystem, error) {
 	return http.FS(fsys), nil
 }
 
-func ServeIndex(w http.ResponseWriter, r *http.Request) {
+func NewIndexHandler() (http.HandlerFunc, error) {
 	indexPath := filepath.Join("build", "index.html")
-	// TODO: read this at startup
 	p, err := assets.ReadFile(indexPath)
 	if err != nil {
-		fmt.Println("err", err)
-		panic("missing file")
-		// TODO: Handle error as appropriate for the application.
+		return nil, err
 	}
-	w.Write(p)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Write(p)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}, nil
 }

--- a/public/assets_embedded.go
+++ b/public/assets_embedded.go
@@ -33,9 +33,9 @@ func NewIndexHandler() (http.HandlerFunc, error) {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Write(p)
+		_, err := w.Write(p)
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}, nil
 }

--- a/public/assets_embedded.go
+++ b/public/assets_embedded.go
@@ -5,8 +5,10 @@ package public
 
 import (
 	"embed"
+	"fmt"
 	"io/fs"
 	"net/http"
+	"path/filepath"
 )
 
 var AssetsEmbedded = true
@@ -22,4 +24,16 @@ func Assets() (http.FileSystem, error) {
 	}
 
 	return http.FS(fsys), nil
+}
+
+func ServeIndex(w http.ResponseWriter, r *http.Request) {
+	indexPath := filepath.Join("build", "index.html")
+	// TODO: read this at startup
+	p, err := assets.ReadFile(indexPath)
+	if err != nil {
+		fmt.Println("err", err)
+		panic("missing file")
+		// TODO: Handle error as appropriate for the application.
+	}
+	w.Write(p)
 }

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -4,6 +4,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const {
   dependencies: pyroOSSDeps,
 } = require('../../node_modules/pyroscope-oss/package.json');
+const webpack = require('webpack');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 // this is so that we don't import dependencies twice, once from pyroscope-oss and another from here
@@ -21,7 +22,7 @@ module.exports = {
   },
   output: {
     clean: true,
-    path: path.resolve(__dirname, '../../public/build/assets'),
+    path: path.resolve(__dirname, '../../public/build'),
     filename: '[name].[contenthash].js',
     publicPath: '',
   },

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -106,14 +106,7 @@ module.exports = {
     children: false,
     source: false,
   },
-  plugins: [
-    new MiniCssExtractPlugin({}),
-    new HtmlWebpackPlugin({
-      filename: path.resolve(__dirname, '../../public/build/index.html'),
-      template: path.resolve(__dirname, '../../public/templates/index.html'),
-      chunksSortMode: 'none',
-    }),
-  ],
+  plugins: [new MiniCssExtractPlugin({})],
   module: {
     rules: [
       // CSS

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   output: {
     clean: true,
-    path: path.resolve(__dirname, '../../public/build'),
+    path: path.resolve(__dirname, '../../public/build/assets'),
     filename: '[name].[contenthash].js',
     publicPath: '',
   },

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -15,4 +15,9 @@ module.exports = merge(common, {
   optimization: {
     runtimeChunk: 'single',
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.BASEPATH': JSON.stringify(''),
+    }),
+  ],
 });

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -1,5 +1,6 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common');
+const webpack = require('webpack');
 
 module.exports = merge(common, {
   devtool: 'eval-source-map',

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -1,4 +1,5 @@
 const { merge } = require('webpack-merge');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 const common = require('./webpack.common');
 const webpack = require('webpack');
 
@@ -19,6 +20,12 @@ module.exports = merge(common, {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.BASEPATH': JSON.stringify(''),
+    }),
+    // Duplicated in webpack.prod.js
+    new HtmlWebpackPlugin({
+      filename: path.resolve(__dirname, '../../public/build/index.html'),
+      template: path.resolve(__dirname, '../../public/templates/index.html'),
+      chunksSortMode: 'none',
     }),
   ],
 });

--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -1,6 +1,18 @@
 const { merge } = require('webpack-merge');
+const webpack = require('webpack');
+const path = require('path');
 const common = require('./webpack.common');
 
 module.exports = merge(common, {
   mode: 'production',
+  output: {
+    clean: true,
+    path: path.resolve(__dirname, '../../public/build/assets'),
+    publicPath: 'assets',
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.BASEPATH': JSON.stringify('/ui'),
+    }),
+  ],
 });

--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -1,5 +1,6 @@
 const { merge } = require('webpack-merge');
 const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const common = require('./webpack.common');
 
@@ -13,6 +14,13 @@ module.exports = merge(common, {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.BASEPATH': JSON.stringify('/ui'),
+    }),
+    // Duplicated in webpack.dev.js
+    new HtmlWebpackPlugin({
+      base: { href: '/ui/' },
+      filename: path.resolve(__dirname, '../../public/build/index.html'),
+      template: path.resolve(__dirname, '../../public/templates/index.html'),
+      chunksSortMode: 'none',
     }),
   ],
 });


### PR DESCRIPTION
Fixes https://github.com/grafana/phlare/issues/642

Keep in mind https://github.com/grafana/phlare/issues/638 is still outstanding, but will definitely build upon the work here.

# How it works
## Dev mode (`yarn dev`)
Backend doesn't do anything.
Basepath is `/` since it's served under `http://localhost:4040`

## Prod mode (`make build`)
Backend serves `/ui/assets` requests (css/js) using the embed file server.
All other routes are served the `index.html`, which then are handled via the frontend router (`react-router`).
When building for production, a `BASEPATH` env var is dynamically set in webpack to `/ui`. This is so that React Router knows that it needs to take that into account. This part will likely change when https://github.com/grafana/phlare/issues/638 is addressed. 
