### PR TITLE
Remove `cortex_` prefix from scheduler/frontend metrics

### DIFF
--- a/docs/sources/operators-guide/configure/configuring-memberlist.md
+++ b/docs/sources/operators-guide/configure/configuring-memberlist.md
@@ -51,7 +51,7 @@ If you run multiple Phlare processes on the same node or the port `7946` is not 
 
 ### Fine tuning memberlist changes propagation latency
 
-The `cortex_ring_oldest_member_timestamp` metric can be used to measure the propagation of hash ring changes.
+The `phlare_ring_oldest_member_timestamp` metric can be used to measure the propagation of hash ring changes.
 This metric tracks the oldest heartbeat timestamp across all instances in the ring.
 You can execute the following query to measure the age of the oldest heartbeat timestamp in the ring:
 

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -143,14 +143,14 @@ func NewFrontend(cfg Config, log log.Logger, reg prometheus.Registerer) (*Fronte
 	f.lastQueryID.Store(rand.Uint64())
 
 	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "cortex_query_frontend_queries_in_progress",
+		Name: "phlare_query_frontend_queries_in_progress",
 		Help: "Number of queries in progress handled by this frontend.",
 	}, func() float64 {
 		return float64(f.requests.count())
 	})
 
 	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "cortex_query_frontend_connected_schedulers",
+		Name: "phlare_query_frontend_connected_schedulers",
 		Help: "Number of schedulers this frontend is connected to.",
 	}, func() float64 {
 		return float64(f.schedulerWorkers.getWorkersCount())

--- a/pkg/frontend/frontend_scheduler_worker.go
+++ b/pkg/frontend/frontend_scheduler_worker.go
@@ -69,7 +69,7 @@ func newFrontendSchedulerWorkers(cfg Config, frontendAddress string, requestsCh 
 		workers:                   map[string]*frontendSchedulerWorker{},
 		schedulerDiscoveryWatcher: services.NewFailureWatcher(),
 		enqueuedRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_query_frontend_workers_enqueued_requests_total",
+			Name: "phlare_query_frontend_workers_enqueued_requests_total",
 			Help: "Total number of requests enqueued by each query frontend worker (regardless of the result), labeled by scheduler address.",
 		}, []string{schedulerAddressLabel}),
 	}

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -156,11 +156,11 @@ func TestFrontendRequestsPerWorkerMetric(t *testing.T) {
 	})
 
 	expectedMetrics := fmt.Sprintf(`
-		# HELP cortex_query_frontend_workers_enqueued_requests_total Total number of requests enqueued by each query frontend worker (regardless of the result), labeled by scheduler address.
-		# TYPE cortex_query_frontend_workers_enqueued_requests_total counter
-		cortex_query_frontend_workers_enqueued_requests_total{scheduler_address="%s"} 0
+		# HELP phlare_query_frontend_workers_enqueued_requests_total Total number of requests enqueued by each query frontend worker (regardless of the result), labeled by scheduler address.
+		# TYPE phlare_query_frontend_workers_enqueued_requests_total counter
+		phlare_query_frontend_workers_enqueued_requests_total{scheduler_address="%s"} 0
 	`, f.cfg.SchedulerAddress)
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_query_frontend_workers_enqueued_requests_total"))
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "phlare_query_frontend_workers_enqueued_requests_total"))
 
 	resp, err := f.RoundTripGRPC(user.InjectOrgID(context.Background(), userID), &httpgrpc.HTTPRequest{})
 	require.NoError(t, err)
@@ -168,16 +168,16 @@ func TestFrontendRequestsPerWorkerMetric(t *testing.T) {
 	require.Equal(t, []byte(body), resp.Body)
 
 	expectedMetrics = fmt.Sprintf(`
-		# HELP cortex_query_frontend_workers_enqueued_requests_total Total number of requests enqueued by each query frontend worker (regardless of the result), labeled by scheduler address.
-		# TYPE cortex_query_frontend_workers_enqueued_requests_total counter
-		cortex_query_frontend_workers_enqueued_requests_total{scheduler_address="%s"} 1
+		# HELP phlare_query_frontend_workers_enqueued_requests_total Total number of requests enqueued by each query frontend worker (regardless of the result), labeled by scheduler address.
+		# TYPE phlare_query_frontend_workers_enqueued_requests_total counter
+		phlare_query_frontend_workers_enqueued_requests_total{scheduler_address="%s"} 1
 	`, f.cfg.SchedulerAddress)
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_query_frontend_workers_enqueued_requests_total"))
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "phlare_query_frontend_workers_enqueued_requests_total"))
 
 	// Manually remove the address, check that label is removed.
 	f.schedulerWorkers.InstanceRemoved(servicediscovery.Instance{Address: f.cfg.SchedulerAddress, InUse: true})
 	expectedMetrics = ``
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_query_frontend_workers_enqueued_requests_total"))
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "phlare_query_frontend_workers_enqueued_requests_total"))
 }
 
 func TestFrontendRetryEnqueue(t *testing.T) {

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -61,14 +61,14 @@ func newSchedulerProcessor(cfg Config, handler RequestHandler, log log.Logger, r
 		},
 
 		frontendClientRequestDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "cortex_querier_query_frontend_request_duration_seconds",
+			Name:    "phlare_querier_query_frontend_request_duration_seconds",
 			Help:    "Time spend doing requests to frontend.",
 			Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
 		}, []string{"operation", "status_code"}),
 	}
 
 	frontendClientsGauge := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Name: "cortex_querier_query_frontend_clients",
+		Name: "phlare_querier_query_frontend_clients",
 		Help: "The current number of clients connected to query-frontend.",
 	})
 

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -29,8 +29,8 @@ func BenchmarkGetNextRequest(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		queue := NewRequestQueue(maxOutstandingPerTenant, 0,
-			promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
-			promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
+			promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"tenant"}),
+			promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"tenant"}),
 		)
 		queues = append(queues, queue)
 
@@ -40,9 +40,9 @@ func BenchmarkGetNextRequest(b *testing.B) {
 
 		for i := 0; i < maxOutstandingPerTenant; i++ {
 			for j := 0; j < numTenants; j++ {
-				userID := strconv.Itoa(j)
+				tenantID := strconv.Itoa(j)
 
-				err := queue.EnqueueRequest(userID, "request", 0, nil)
+				err := queue.EnqueueRequest(tenantID, "request", 0, nil)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -86,7 +86,7 @@ func BenchmarkQueueRequest(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		q := NewRequestQueue(maxOutstandingPerTenant, 0,
-			promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+			promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"tenant"}),
 			promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		)
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -125,36 +125,36 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 	}
 
 	s.queueLength = promauto.With(registerer).NewGaugeVec(prometheus.GaugeOpts{
-		Name: "cortex_query_scheduler_queue_length",
+		Name: "phlare_query_scheduler_queue_length",
 		Help: "Number of queries in the queue.",
-	}, []string{"user"})
+	}, []string{"tenant"})
 
 	s.cancelledRequests = promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-		Name: "cortex_query_scheduler_cancelled_requests_total",
+		Name: "phlare_query_scheduler_cancelled_requests_total",
 		Help: "Total number of query requests that were cancelled after enqueuing.",
-	}, []string{"user"})
+	}, []string{"tenant"})
 	s.discardedRequests = promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-		Name: "cortex_query_scheduler_discarded_requests_total",
+		Name: "phlare_query_scheduler_discarded_requests_total",
 		Help: "Total number of query requests discarded.",
-	}, []string{"user"})
+	}, []string{"tenant"})
 	s.requestQueue = queue.NewRequestQueue(cfg.MaxOutstandingPerTenant, cfg.QuerierForgetDelay, s.queueLength, s.discardedRequests)
 
 	s.queueDuration = promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
-		Name:    "cortex_query_scheduler_queue_duration_seconds",
+		Name:    "phlare_query_scheduler_queue_duration_seconds",
 		Help:    "Time spend by requests in queue before getting picked up by a querier.",
 		Buckets: prometheus.DefBuckets,
 	})
 	s.connectedQuerierClients = promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "cortex_query_scheduler_connected_querier_clients",
+		Name: "phlare_query_scheduler_connected_querier_clients",
 		Help: "Number of querier worker clients currently connected to the query-scheduler.",
 	}, s.requestQueue.GetConnectedQuerierWorkersMetric)
 	s.connectedFrontendClients = promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "cortex_query_scheduler_connected_frontend_clients",
+		Name: "phlare_query_scheduler_connected_frontend_clients",
 		Help: "Number of query-frontend worker clients currently connected to the query-scheduler.",
 	}, s.getConnectedFrontendClientsMetric)
 
 	s.inflightRequests = promauto.With(registerer).NewSummary(prometheus.SummaryOpts{
-		Name:       "cortex_query_scheduler_inflight_requests",
+		Name:       "phlare_query_scheduler_inflight_requests",
 		Help:       "Number of inflight requests (either queued or processing) sampled at a regular interval. Quantile buckets keep track of inflight requests over the last 60s.",
 		Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.02, 0.8: 0.02, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
 		MaxAge:     time.Minute,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -444,19 +444,19 @@ func TestSchedulerMetrics(t *testing.T) {
 	})
 
 	require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-		# HELP cortex_query_scheduler_queue_length Number of queries in the queue.
-		# TYPE cortex_query_scheduler_queue_length gauge
-		cortex_query_scheduler_queue_length{user="another"} 1
-		cortex_query_scheduler_queue_length{user="test"} 1
-	`), "cortex_query_scheduler_queue_length"))
+		# HELP phlare_query_scheduler_queue_length Number of queries in the queue.
+		# TYPE phlare_query_scheduler_queue_length gauge
+		phlare_query_scheduler_queue_length{tenant="another"} 1
+		phlare_query_scheduler_queue_length{tenant="test"} 1
+	`), "phlare_query_scheduler_queue_length"))
 
 	scheduler.cleanupMetricsForInactiveUser("test")
 
 	require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-		# HELP cortex_query_scheduler_queue_length Number of queries in the queue.
-		# TYPE cortex_query_scheduler_queue_length gauge
-		cortex_query_scheduler_queue_length{user="another"} 1
-	`), "cortex_query_scheduler_queue_length"))
+		# HELP phlare_query_scheduler_queue_length Number of queries in the queue.
+		# TYPE phlare_query_scheduler_queue_length gauge
+		phlare_query_scheduler_queue_length{tenant="another"} 1
+	`), "phlare_query_scheduler_queue_length"))
 }
 
 func initFrontendLoop(t *testing.T, client schedulerpb.SchedulerForFrontendClient, frontendAddr string) schedulerpb.SchedulerForFrontend_FrontendLoopClient {

--- a/pkg/scheduler/schedulerdiscovery/ring.go
+++ b/pkg/scheduler/schedulerdiscovery/ring.go
@@ -113,7 +113,7 @@ func (cfg *RingConfig) ToRingConfig() ring.Config {
 
 // NewRingLifecycler creates a new query-scheduler ring lifecycler with all required lifecycler delegates.
 func NewRingLifecycler(cfg RingConfig, logger log.Logger, reg prometheus.Registerer) (*ring.BasicLifecycler, error) {
-	reg = prometheus.WrapRegistererWithPrefix("cortex_", reg)
+	reg = prometheus.WrapRegistererWithPrefix("phlare_", reg)
 	kvStore, err := kv.NewClient(cfg.KVStore, ring.GetCodec(), kv.RegistererWithKVName(reg, "query-scheduler-lifecycler"), logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize query-schedulers' KV store")
@@ -139,7 +139,7 @@ func NewRingLifecycler(cfg RingConfig, logger log.Logger, reg prometheus.Registe
 
 // NewRingClient creates a client for the query-schedulers ring.
 func NewRingClient(cfg RingConfig, component string, logger log.Logger, reg prometheus.Registerer) (*ring.Ring, error) {
-	client, err := ring.New(cfg.ToRingConfig(), component, ringKey, logger, prometheus.WrapRegistererWithPrefix("cortex_", reg))
+	client, err := ring.New(cfg.ToRingConfig(), component, ringKey, logger, prometheus.WrapRegistererWithPrefix("phlare_", reg))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize query-schedulers' ring client")
 	}

--- a/pkg/util/logger.go
+++ b/pkg/util/logger.go
@@ -13,15 +13,15 @@ var Logger = log.NewNopLogger()
 
 // LoggerWithUserID returns a Logger that has information about the current user in
 // its details.
-func LoggerWithUserID(userID string, l log.Logger) log.Logger {
+func LoggerWithUserID(tenantID string, l log.Logger) log.Logger {
 	// See note in WithContext.
-	return log.With(l, "user", userID)
+	return log.With(l, "tenant", tenantID)
 }
 
 // LoggerWithUserIDs returns a Logger that has information about the current user or
 // users (separated by "|") in its details.
-func LoggerWithUserIDs(userIDs []string, l log.Logger) log.Logger {
-	return log.With(l, "user", tenant.JoinTenantIDs(userIDs))
+func LoggerWithUserIDs(tenantIDs []string, l log.Logger) log.Logger {
+	return log.With(l, "tenant", tenant.JoinTenantIDs(tenantIDs))
 }
 
 // LoggerWithTraceID returns a Logger that has information about the traceID in
@@ -37,7 +37,7 @@ func LoggerWithTraceID(traceID string, l log.Logger) log.Logger {
 // e.g.
 //
 //	log = util.WithContext(ctx, log)
-//	# level=error user=user-1|user-2 traceID=123abc msg="Could not chunk chunks" err="an error"
+//	# level=error tenant=user-1|user-2 traceID=123abc msg="Could not chunk chunks" err="an error"
 //	level.Error(log).Log("msg", "Could not chunk chunks", "err", err)
 func LoggerWithContext(ctx context.Context, l log.Logger) log.Logger {
 	// Weaveworks uses "orgs" and "orgID" to represent Cortex users,


### PR DESCRIPTION
This is misleading and really hard to fix later, this will also require to modify some of the existing dashboards.

In my opinion, we should also rename all metrics to use the `pyroscope_` prefix 