### PR TITLE
Update all metrics to be prefixed with pyroscope rather than phlare

### DIFF
--- a/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/dashboards/dashboard-utils.libsonnet
@@ -29,15 +29,15 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
       addCluster(multi=false)::
         if multi then
-          self.addMultiTemplate('cluster', 'phlare_build_info', $._config.per_cluster_label)
+          self.addMultiTemplate('cluster', 'pyroscope_build_info', $._config.per_cluster_label)
         else
-          self.addTemplate('cluster', 'phlare_build_info', $._config.per_cluster_label),
+          self.addTemplate('cluster', 'pyroscope_build_info', $._config.per_cluster_label),
 
       addNamespace(multi=false)::
         if multi then
-          self.addMultiTemplate('namespace', 'phlare_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace')
+          self.addMultiTemplate('namespace', 'pyroscope_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace')
         else
-          self.addTemplate('namespace', 'phlare_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace'),
+          self.addTemplate('namespace', 'pyroscope_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace'),
 
       addTag()::
         self + {
@@ -74,11 +74,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         };
 
         if multi then
-          d.addMultiTemplate('cluster', 'phlare_build_info', $._config.per_cluster_label)
-          .addMultiTemplate('namespace', 'phlare_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace')
+          d.addMultiTemplate('cluster', 'pyroscope_build_info', $._config.per_cluster_label)
+          .addMultiTemplate('namespace', 'pyroscope_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace')
         else
-          d.addTemplate('cluster', 'phlare_build_info', $._config.per_cluster_label)
-          .addTemplate('namespace', 'phlare_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace'),
+          d.addTemplate('cluster', 'pyroscope_build_info', $._config.per_cluster_label)
+          .addTemplate('namespace', 'pyroscope_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace'),
     },
 
   jobMatcher(job)::

--- a/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/dashboards/phlare-reads.libsonnet
+++ b/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/dashboards/phlare-reads.libsonnet
@@ -36,12 +36,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
                            $.row('Querier')
                            .addPanel(
                              $.panel('QPS') +
-                             $.qpsPanel('phlare_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['phlare-reads.json'].querierSelector, http_route])
+                             $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['phlare-reads.json'].querierSelector, http_route])
                            )
                            .addPanel(
                              $.panel('Latency') +
                              utils.latencyRecordingRulePanel(
-                               'phlare_request_duration_seconds',
+                               'pyroscope_request_duration_seconds',
                                dashboards['phlare-reads.json'].matchers.querier + [utils.selector.re('route', http_route)] + dashboards['phlare-reads.json'].clusterMatchers,
                                sum_by=['route']
                              )
@@ -51,12 +51,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
                            $.row('Ingester')
                            .addPanel(
                              $.panel('QPS') +
-                             $.qpsPanel('phlare_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['phlare-reads.json'].ingesterSelector, http_route])
+                             $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['phlare-reads.json'].ingesterSelector, http_route])
                            )
                            .addPanel(
                              $.panel('Latency') +
                              utils.latencyRecordingRulePanel(
-                               'phlare_request_duration_seconds',
+                               'pyroscope_request_duration_seconds',
                                dashboards['phlare-reads.json'].matchers.ingester + [utils.selector.re('route', http_route)] + dashboards['phlare-reads.json'].clusterMatchers,
                                sum_by=['route']
                              )

--- a/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/dashboards/phlare-writes.libsonnet
+++ b/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/dashboards/phlare-writes.libsonnet
@@ -40,7 +40,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                             .addPanel(
                               $.panel('Compressed Size') +
                               utils.latencyRecordingRulePanel(
-                                'phlare_distributor_received_compressed_bytes',
+                                'pyroscope_distributor_received_compressed_bytes',
                                 dashboards['phlare-writes.json'].matchers.distributor + [utils.selector.re('type', '.*')] + dashboards['phlare-writes.json'].clusterMatchers,
                                 multiplier='1',
                                 sum_by=['type'],
@@ -49,7 +49,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                             .addPanel(
                               $.panel('Samples') +
                               utils.latencyRecordingRulePanel(
-                                'phlare_distributor_received_samples',
+                                'pyroscope_distributor_received_samples',
                                 dashboards['phlare-writes.json'].matchers.distributor + [utils.selector.re('type', '.*')] + dashboards['phlare-writes.json'].clusterMatchers,
                                 multiplier='1',
                                 sum_by=['type'],
@@ -60,12 +60,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
                             $.row('Distributor Requests')
                             .addPanel(
                               $.panel('QPS') +
-                              $.qpsPanel('phlare_request_duration_seconds_count{%s, route=~".*push.*"}' % std.rstripChars(dashboards['phlare-writes.json'].distributorSelector, ','))
+                              $.qpsPanel('pyroscope_request_duration_seconds_count{%s, route=~".*push.*"}' % std.rstripChars(dashboards['phlare-writes.json'].distributorSelector, ','))
                             )
                             .addPanel(
                               $.panel('Latency') +
                               utils.latencyRecordingRulePanel(
-                                'phlare_request_duration_seconds',
+                                'pyroscope_request_duration_seconds',
                                 dashboards['phlare-writes.json'].matchers.distributor + [utils.selector.re('route', '.*push.*')] + dashboards['phlare-writes.json'].clusterMatchers,
                               )
                             )
@@ -74,12 +74,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
                             $.row('Ingester')
                             .addPanel(
                               $.panel('QPS') +
-                              $.qpsPanel('phlare_request_duration_seconds_count{%s route=~".*push.*"}' % dashboards['phlare-writes.json'].ingesterSelector)
+                              $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~".*push.*"}' % dashboards['phlare-writes.json'].ingesterSelector)
                             )
                             .addPanel(
                               $.panel('Latency') +
                               utils.latencyRecordingRulePanel(
-                                'phlare_request_duration_seconds',
+                                'pyroscope_request_duration_seconds',
                                 dashboards['phlare-writes.json'].matchers.ingester + [utils.selector.re('route', '.*push.*')] + dashboards['phlare-writes.json'].clusterMatchers,
                               )
                             )
@@ -97,14 +97,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
                               local short_desc = 'Head size in bytes per table type';
                               $.panel(short_desc) +
                               $.panelDescription(short_desc, long_desc,) +
-                              $.queryPanel('sum(phlare_head_size_bytes{%s}) by (type)' % dashboards['phlare-writes.json'].ingesterSelector, '{{type}}') +
+                              $.queryPanel('sum(pyroscope_head_size_bytes{%s}) by (type)' % dashboards['phlare-writes.json'].ingesterSelector, '{{type}}') +
                               { yaxes: $.yaxes('bytes') },
                             )
                             .addPanel(
                               local short_desc = 'Head size in bytes per pod';
                               $.panel(short_desc) +
                               $.panelDescription(short_desc, long_desc,) +
-                              $.queryPanel('sum(phlare_head_size_bytes{%s}) by (instance)' % dashboards['phlare-writes.json'].ingesterSelector, '{{instance}}') +
+                              $.queryPanel('sum(pyroscope_head_size_bytes{%s}) by (instance)' % dashboards['phlare-writes.json'].ingesterSelector, '{{instance}}') +
                               { yaxes: $.yaxes('bytes') },
                             )
                           ),

--- a/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/recording_rules.libsonnet
+++ b/operations/phlare/jsonnet/phlare-mixin/phlare-mixin/recording_rules.libsonnet
@@ -3,14 +3,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
 {
   prometheusRules+:: {
     groups+: [{
-      name: 'phlare_rules',
+      name: 'pyroscope_rules',
       local cluster = if $._config.multi_cluster then [$._config.per_cluster_label] else [],
       rules:
-        utils.histogramRules('phlare_request_duration_seconds', ['job'] + cluster) +
-        utils.histogramRules('phlare_request_duration_seconds', ['job', 'route'] + cluster) +
-        utils.histogramRules('phlare_request_duration_seconds', ['namespace', 'job', 'route'] + cluster) +
-        utils.histogramRules('phlare_distributor_received_compressed_bytes', ['job', 'type'] + cluster) +
-        utils.histogramRules('phlare_distributor_received_samples', ['job', 'type'] + cluster),
+        utils.histogramRules('pyroscope_request_duration_seconds', ['job'] + cluster) +
+        utils.histogramRules('pyroscope_request_duration_seconds', ['job', 'route'] + cluster) +
+        utils.histogramRules('pyroscope_request_duration_seconds', ['namespace', 'job', 'route'] + cluster) +
+        utils.histogramRules('pyroscope_distributor_received_compressed_bytes', ['job', 'type'] + cluster) +
+        utils.histogramRules('pyroscope_distributor_received_samples', ['job', 'type'] + cluster),
     }],
   },
 }

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -107,7 +107,7 @@ type Limits interface {
 
 func New(cfg Config, ingestersRing ring.ReadRing, factory ring_client.PoolFactory, limits Limits, reg prometheus.Registerer, logger log.Logger, clientsOptions ...connect.ClientOption) (*Distributor, error) {
 	clients := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Namespace: "phlare",
+		Namespace: "pyroscope",
 		Name:      "distributor_ingester_clients",
 		Help:      "The current number of ingester clients.",
 	})
@@ -435,7 +435,7 @@ func TokenFor(tenantID, labels string) uint32 {
 
 // newRingAndLifecycler creates a new distributor ring and lifecycler with all required lifecycler delegates
 func newRingAndLifecycler(cfg RingConfig, instanceCount *atomic.Uint32, logger log.Logger, reg prometheus.Registerer) (*ring.Ring, *ring.BasicLifecycler, error) {
-	reg = prometheus.WrapRegistererWithPrefix("phlare_", reg)
+	reg = prometheus.WrapRegistererWithPrefix("pyroscope_", reg)
 	kvStore, err := kv.NewClient(cfg.KVStore, ring.GetCodec(), kv.RegistererWithKVName(reg, "distributor-lifecycler"), logger)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to initialize distributors' KV store")

--- a/pkg/distributor/metrics.go
+++ b/pkg/distributor/metrics.go
@@ -22,13 +22,13 @@ type metrics struct {
 func newMetrics(reg prometheus.Registerer) *metrics {
 	m := &metrics{
 		replicationFactor: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "phlare",
+			Namespace: "pyroscope",
 			Name:      "distributor_replication_factor",
 			Help:      "The configured replication factor for the distributor.",
 		}),
 		receivedCompressedBytes: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Namespace: "phlare",
+				Namespace: "pyroscope",
 				Name:      "distributor_received_compressed_bytes",
 				Help:      "The number of compressed bytes per profile received by the distributor.",
 				Buckets:   prometheus.ExponentialBucketsRange(minBytes, maxBytes, bucketsCount),
@@ -37,7 +37,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		),
 		receivedDecompressedBytes: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Namespace: "phlare",
+				Namespace: "pyroscope",
 				Name:      "distributor_received_decompressed_bytes",
 				Help:      "The number of decompressed bytes per profiles received by the distributor.",
 				Buckets:   prometheus.ExponentialBucketsRange(minBytes, maxBytes, bucketsCount),
@@ -46,7 +46,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		),
 		receivedSamples: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Namespace: "phlare",
+				Namespace: "pyroscope",
 				Name:      "distributor_received_samples",
 				Help:      "The number of samples per profile name received by the distributor.",
 				Buckets:   prometheus.ExponentialBucketsRange(100, 100000, 30),
@@ -55,7 +55,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		),
 		receivedSamplesBytes: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Namespace: "phlare",
+				Namespace: "pyroscope",
 				Name:      "distributor_received_samples_bytes",
 				Help:      "The size of samples without symbols received by the distributor.",
 				Buckets:   prometheus.ExponentialBucketsRange(10*1024, 15*1024*1024, 30),
@@ -64,7 +64,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		),
 		receivedSymbolsBytes: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Namespace: "phlare",
+				Namespace: "pyroscope",
 				Name:      "distributor_received_symbols_bytes",
 				Help:      "The size of symbols received by the distributor.",
 				Buckets:   prometheus.ExponentialBucketsRange(10*1024, 15*1024*1024, 30),

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -143,14 +143,14 @@ func NewFrontend(cfg Config, log log.Logger, reg prometheus.Registerer) (*Fronte
 	f.lastQueryID.Store(rand.Uint64())
 
 	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "phlare_query_frontend_queries_in_progress",
+		Name: "pyroscope_query_frontend_queries_in_progress",
 		Help: "Number of queries in progress handled by this frontend.",
 	}, func() float64 {
 		return float64(f.requests.count())
 	})
 
 	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "phlare_query_frontend_connected_schedulers",
+		Name: "pyroscope_query_frontend_connected_schedulers",
 		Help: "Number of schedulers this frontend is connected to.",
 	}, func() float64 {
 		return float64(f.schedulerWorkers.getWorkersCount())

--- a/pkg/frontend/frontend_scheduler_worker.go
+++ b/pkg/frontend/frontend_scheduler_worker.go
@@ -69,7 +69,7 @@ func newFrontendSchedulerWorkers(cfg Config, frontendAddress string, requestsCh 
 		workers:                   map[string]*frontendSchedulerWorker{},
 		schedulerDiscoveryWatcher: services.NewFailureWatcher(),
 		enqueuedRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "phlare_query_frontend_workers_enqueued_requests_total",
+			Name: "pyroscope_query_frontend_workers_enqueued_requests_total",
 			Help: "Total number of requests enqueued by each query frontend worker (regardless of the result), labeled by scheduler address.",
 		}, []string{schedulerAddressLabel}),
 	}

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -156,11 +156,11 @@ func TestFrontendRequestsPerWorkerMetric(t *testing.T) {
 	})
 
 	expectedMetrics := fmt.Sprintf(`
-		# HELP phlare_query_frontend_workers_enqueued_requests_total Total number of requests enqueued by each query frontend worker (regardless of the result), labeled by scheduler address.
-		# TYPE phlare_query_frontend_workers_enqueued_requests_total counter
-		phlare_query_frontend_workers_enqueued_requests_total{scheduler_address="%s"} 0
+		# HELP pyroscope_query_frontend_workers_enqueued_requests_total Total number of requests enqueued by each query frontend worker (regardless of the result), labeled by scheduler address.
+		# TYPE pyroscope_query_frontend_workers_enqueued_requests_total counter
+		pyroscope_query_frontend_workers_enqueued_requests_total{scheduler_address="%s"} 0
 	`, f.cfg.SchedulerAddress)
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "phlare_query_frontend_workers_enqueued_requests_total"))
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "pyroscope_query_frontend_workers_enqueued_requests_total"))
 
 	resp, err := f.RoundTripGRPC(user.InjectOrgID(context.Background(), userID), &httpgrpc.HTTPRequest{})
 	require.NoError(t, err)
@@ -168,16 +168,16 @@ func TestFrontendRequestsPerWorkerMetric(t *testing.T) {
 	require.Equal(t, []byte(body), resp.Body)
 
 	expectedMetrics = fmt.Sprintf(`
-		# HELP phlare_query_frontend_workers_enqueued_requests_total Total number of requests enqueued by each query frontend worker (regardless of the result), labeled by scheduler address.
-		# TYPE phlare_query_frontend_workers_enqueued_requests_total counter
-		phlare_query_frontend_workers_enqueued_requests_total{scheduler_address="%s"} 1
+		# HELP pyroscope_query_frontend_workers_enqueued_requests_total Total number of requests enqueued by each query frontend worker (regardless of the result), labeled by scheduler address.
+		# TYPE pyroscope_query_frontend_workers_enqueued_requests_total counter
+		pyroscope_query_frontend_workers_enqueued_requests_total{scheduler_address="%s"} 1
 	`, f.cfg.SchedulerAddress)
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "phlare_query_frontend_workers_enqueued_requests_total"))
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "pyroscope_query_frontend_workers_enqueued_requests_total"))
 
 	// Manually remove the address, check that label is removed.
 	f.schedulerWorkers.InstanceRemoved(servicediscovery.Instance{Address: f.cfg.SchedulerAddress, InUse: true})
 	expectedMetrics = ``
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "phlare_query_frontend_workers_enqueued_requests_total"))
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "pyroscope_query_frontend_workers_enqueued_requests_total"))
 }
 
 func TestFrontendRetryEnqueue(t *testing.T) {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -93,7 +93,7 @@ func New(phlarectx context.Context, cfg Config, dbConfig phlaredb.Config, storag
 		"ingester",
 		"ring",
 		true,
-		i.logger, prometheus.WrapRegistererWithPrefix("phlare_", i.reg))
+		i.logger, prometheus.WrapRegistererWithPrefix("pyroscope_", i.reg))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -109,7 +109,7 @@ func (f *Phlare) initRuntimeConfig() (services.Service, error) {
 	// make sure to set default limits before we start loading configuration into memory
 	validation.SetDefaultLimitsForYAMLUnmarshalling(f.Cfg.LimitsConfig)
 
-	serv, err := runtimeconfig.New(f.Cfg.RuntimeConfig, prometheus.WrapRegistererWithPrefix("phlare_", f.reg), log.With(f.logger, "component", "runtime-config"))
+	serv, err := runtimeconfig.New(f.Cfg.RuntimeConfig, prometheus.WrapRegistererWithPrefix("pyroscope_", f.reg), log.With(f.logger, "component", "runtime-config"))
 	if err == nil {
 		// TenantLimits just delegates to RuntimeConfig and doesn't have any state or need to do
 		// anything in the start/stopping phase. Thus we can create it as part of runtime config
@@ -273,7 +273,7 @@ func (f *Phlare) initMemberlistKV() (services.Service, error) {
 	}
 
 	dnsProviderReg := prometheus.WrapRegistererWithPrefix(
-		"phlare_",
+		"pyroscope_",
 		prometheus.WrapRegistererWith(
 			prometheus.Labels{"name": "memberlist"},
 			f.reg,
@@ -297,7 +297,7 @@ func (f *Phlare) initMemberlistKV() (services.Service, error) {
 }
 
 func (f *Phlare) initRing() (_ services.Service, err error) {
-	f.ring, err = ring.New(f.Cfg.Ingester.LifecyclerConfig.RingConfig, "ingester", "ring", log.With(f.logger, "component", "ring"), prometheus.WrapRegistererWithPrefix("phlare_", f.reg))
+	f.ring, err = ring.New(f.Cfg.Ingester.LifecyclerConfig.RingConfig, "ingester", "ring", log.With(f.logger, "component", "ring"), prometheus.WrapRegistererWithPrefix("pyroscope_", f.reg))
 	if err != nil {
 		return nil, err
 	}
@@ -348,14 +348,14 @@ func (f *Phlare) initIngester() (_ services.Service, err error) {
 }
 
 func (f *Phlare) initServer() (services.Service, error) {
-	f.reg.MustRegister(version.NewCollector("phlare"))
+	f.reg.MustRegister(version.NewCollector("pyroscope"))
 	f.reg.Unregister(collectors.NewGoCollector())
 	// register collector with additional metrics
 	f.reg.MustRegister(collectors.NewGoCollector(
 		collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll),
 	))
 	DisableSignalHandling(&f.Cfg.Server)
-	f.Cfg.Server.Registerer = prometheus.WrapRegistererWithPrefix("phlare_", f.reg)
+	f.Cfg.Server.Registerer = prometheus.WrapRegistererWithPrefix("pyroscope_", f.reg)
 	// Not all default middleware works with http2 so we'll add then manually.
 	// see https://github.com/grafana/phlare/issues/231
 	f.Cfg.Server.DoNotAddDefaultHTTPMiddleware = true

--- a/pkg/phlaredb/head_test.go
+++ b/pkg/phlaredb/head_test.go
@@ -187,30 +187,30 @@ func TestHeadMetrics(t *testing.T) {
 	time.Sleep(time.Second)
 	require.NoError(t, testutil.GatherAndCompare(head.reg,
 		strings.NewReader(`
-# HELP phlare_head_ingested_sample_values_total Number of sample values ingested into the head per profile type.
-# TYPE phlare_head_ingested_sample_values_total counter
-phlare_head_ingested_sample_values_total{profile_name=""} 3
-# HELP phlare_head_profiles_created_total Total number of profiles created in the head
-# TYPE phlare_head_profiles_created_total counter
-phlare_head_profiles_created_total{profile_name=""} 2
-# HELP phlare_head_received_sample_values_total Number of sample values received into the head per profile type.
-# TYPE phlare_head_received_sample_values_total counter
-phlare_head_received_sample_values_total{profile_name=""} 3
+# HELP pyroscope_head_ingested_sample_values_total Number of sample values ingested into the head per profile type.
+# TYPE pyroscope_head_ingested_sample_values_total counter
+pyroscope_head_ingested_sample_values_total{profile_name=""} 3
+# HELP pyroscope_head_profiles_created_total Total number of profiles created in the head
+# TYPE pyroscope_head_profiles_created_total counter
+pyroscope_head_profiles_created_total{profile_name=""} 2
+# HELP pyroscope_head_received_sample_values_total Number of sample values received into the head per profile type.
+# TYPE pyroscope_head_received_sample_values_total counter
+pyroscope_head_received_sample_values_total{profile_name=""} 3
 
-# HELP phlare_head_size_bytes Size of a particular in memory store within the head phlaredb block.
-# TYPE phlare_head_size_bytes gauge
-phlare_head_size_bytes{type="functions"} 240
-phlare_head_size_bytes{type="locations"} 344
-phlare_head_size_bytes{type="mappings"} 192
-phlare_head_size_bytes{type="profiles"} 416
-phlare_head_size_bytes{type="stacktraces"} 104
-phlare_head_size_bytes{type="strings"} 52
+# HELP pyroscope_head_size_bytes Size of a particular in memory store within the head phlaredb block.
+# TYPE pyroscope_head_size_bytes gauge
+pyroscope_head_size_bytes{type="functions"} 240
+pyroscope_head_size_bytes{type="locations"} 344
+pyroscope_head_size_bytes{type="mappings"} 192
+pyroscope_head_size_bytes{type="profiles"} 416
+pyroscope_head_size_bytes{type="stacktraces"} 104
+pyroscope_head_size_bytes{type="strings"} 52
 
 `),
-		"phlare_head_received_sample_values_total",
-		"phlare_head_profiles_created_total",
-		"phlare_head_ingested_sample_values_total",
-		"phlare_head_size_bytes",
+		"pyroscope_head_received_sample_values_total",
+		"pyroscope_head_profiles_created_total",
+		"pyroscope_head_ingested_sample_values_total",
+		"pyroscope_head_size_bytes",
 	))
 }
 

--- a/pkg/phlaredb/metrics.go
+++ b/pkg/phlaredb/metrics.go
@@ -46,101 +46,101 @@ type headMetrics struct {
 func newHeadMetrics(reg prometheus.Registerer) *headMetrics {
 	m := &headMetrics{
 		seriesCreated: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "phlare_tsdb_head_series_created_total",
+			Name: "pyroscope_tsdb_head_series_created_total",
 			Help: "Total number of series created in the head",
 		}, []string{"profile_name"}),
 		rowsWritten: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "phlare_rows_written",
+				Name: "pyroscope_rows_written",
 				Help: "Number of rows written to a parquet table.",
 			},
 			[]string{"type"}),
 		profilesCreated: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "phlare_head_profiles_created_total",
+			Name: "pyroscope_head_profiles_created_total",
 			Help: "Total number of profiles created in the head",
 		}, []string{"profile_name"}),
 		sampleValuesIngested: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "phlare_head_ingested_sample_values_total",
+				Name: "pyroscope_head_ingested_sample_values_total",
 				Help: "Number of sample values ingested into the head per profile type.",
 			},
 			[]string{"profile_name"}),
 		sampleValuesReceived: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "phlare_head_received_sample_values_total",
+				Name: "pyroscope_head_received_sample_values_total",
 				Help: "Number of sample values received into the head per profile type.",
 			},
 			[]string{"profile_name"}),
 		sizeBytes: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "phlare_head_size_bytes",
+				Name: "pyroscope_head_size_bytes",
 				Help: "Size of a particular in memory store within the head phlaredb block.",
 			},
 			[]string{"type"}),
 		series: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "phlare_tsdb_head_series",
+			Name: "pyroscope_tsdb_head_series",
 			Help: "Total number of series in the head block.",
 		}),
 		profiles: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "phlare_head_profiles",
+			Name: "pyroscope_head_profiles",
 			Help: "Total number of profiles in the head block.",
 		}),
 		flushedFileSizeBytes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: "phlare_head_flushed_table_size_bytes",
+			Name: "pyroscope_head_flushed_table_size_bytes",
 			Help: "Size of a flushed table in bytes.",
 			//  [2MB, 4MB, 8MB, 16MB, 32MB, 64MB, 128MB, 256MB, 512MB, 1GB, 2GB]
 			Buckets: prometheus.ExponentialBuckets(2*1024*1024, 2, 11),
 		}, []string{"name"}),
 		flushedBlockSizeBytes: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "phlare_head_flushed_block_size_bytes",
+			Name: "pyroscope_head_flushed_block_size_bytes",
 			Help: "Size of a flushed block in bytes.",
 			// [50MB, 75MB, 112.5MB, 168.75MB, 253.125MB, 379.688MB, 569.532MB, 854.298MB, 1.281MB, 1.922MB, 2.883MB]
 			Buckets: prometheus.ExponentialBuckets(50*1024*1024, 1.5, 11),
 		}),
 		flushedBlockDurationSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "phlare_head_flushed_block_duration_seconds",
+			Name: "pyroscope_head_flushed_block_duration_seconds",
 			Help: "Time to flushed a block in seconds.",
 			// [5s, 7.5s, 11.25s, 16.875s, 25.3125s, 37.96875s, 56.953125s, 85.4296875s, 128.14453125s, 192.216796875s]
 			Buckets: prometheus.ExponentialBuckets(5, 1.5, 10),
 		}),
 		flushedBlockSeries: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "phlare_head_flushed_block_series",
+			Name: "pyroscope_head_flushed_block_series",
 			Help: "Number of series in a flushed block.",
 			// [1k, 3k, 5k, 7k, 9k, 11k, 13k, 15k, 17k, 19k]
 			Buckets: prometheus.LinearBuckets(1000, 2000, 10),
 		}),
 		flushedBlockSamples: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "phlare_head_flushed_block_samples",
+			Name: "pyroscope_head_flushed_block_samples",
 			Help: "Number of samples in a flushed block.",
 			// [200k, 400k, 800k, 1.6M, 3.2M, 6.4M, 12.8M, 25.6M, 51.2M, 102.4M, 204.8M, 409.6M, 819.2M, 1.6384G, 3.2768G]
 			Buckets: prometheus.ExponentialBuckets(200_000, 2, 15),
 		}),
 		flusehdBlockProfiles: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "phlare_head_flushed_block_profiles",
+			Name: "pyroscope_head_flushed_block_profiles",
 			Help: "Number of profiles in a flushed block.",
 			// [20k, 40k, 80k, 160k, 320k, 640k, 1.28M, 2.56M, 5.12M, 10.24M]
 			Buckets: prometheus.ExponentialBuckets(20_000, 2, 10),
 		}),
 		blockDurationSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "phlare_head_block_duration_seconds",
+			Name: "pyroscope_head_block_duration_seconds",
 			Help: "Duration of a block in seconds (the range it covers).",
 			// [20m, 40m, 1h, 1h20, 1h40, 2h, 2h20, 2h40, 3h, 3h20, 3h40, 4h, 4h20, 4h40, 5h, 5h20, 5h40, 6h, 6h20, 6h40, 7h, 7h20, 7h40, 8h]
 			Buckets: prometheus.LinearBuckets(1200, 1200, 24),
 		}),
 		flushedBlocks: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "phlare_head_flushed_blocks_total",
+			Name: "pyroscope_head_flushed_blocks_total",
 			Help: "Total number of blocks flushed.",
 		}, []string{"status"}),
 		flushedBlocksReasons: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "phlare_head_flushed_reason_total",
+			Name: "pyroscope_head_flushed_reason_total",
 			Help: "Total count of reasons why block has been flushed.",
 		}, []string{"reason"}),
 		writtenProfileSegments: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "phlare_head_written_profile_segments_total",
+			Name: "pyroscope_head_written_profile_segments_total",
 			Help: "Total number and status of profile row groups segments written.",
 		}, []string{"status"}),
 		writtenProfileSegmentsBytes: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "phlare_head_written_profile_segments_size_bytes",
+			Name: "pyroscope_head_written_profile_segments_size_bytes",
 			Help: "Size of a flushed table in bytes.",
 			//  [512KB, 1MB, 2MB, 4MB, 8MB, 16MB, 32MB, 64MB, 128MB, 256MB, 512MB]
 			Buckets: prometheus.ExponentialBuckets(512*1024, 2, 11),
@@ -198,7 +198,7 @@ func newBlocksMetrics(reg prometheus.Registerer) *blocksMetrics {
 	m := &blocksMetrics{
 		query: query.NewMetrics(reg),
 		blockOpeningLatency: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "phlaredb_block_opening_duration",
+			Name: "pyroscopedb_block_opening_duration",
 			Help: "Latency of opening a block in seconds",
 		}),
 	}

--- a/pkg/phlaredb/metrics_test.go
+++ b/pkg/phlaredb/metrics_test.go
@@ -19,8 +19,8 @@ func TestMultipleRegistrationMetrics(t *testing.T) {
 
 	// collect metrics and compare them
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
-# HELP phlare_head_profiles_created_total Total number of profiles created in the head
-# TYPE phlare_head_profiles_created_total counter
-phlare_head_profiles_created_total{profile_name="test"} 2
-`), "phlare_head_profiles_created_total"))
+# HELP pyroscope_head_profiles_created_total Total number of profiles created in the head
+# TYPE pyroscope_head_profiles_created_total counter
+pyroscope_head_profiles_created_total{profile_name="test"} 2
+`), "pyroscope_head_profiles_created_total"))
 }

--- a/pkg/phlaredb/phlaredb.go
+++ b/pkg/phlaredb/phlaredb.go
@@ -130,7 +130,7 @@ func New(phlarectx context.Context, cfg Config, limiter TenantLimiter) (*PhlareD
 	f.wg.Add(1)
 	go f.loop()
 
-	bucketReader := client.ReaderAtBucket(pathLocal, fs, prometheus.WrapRegistererWithPrefix("phlaredb_", reg))
+	bucketReader := client.ReaderAtBucket(pathLocal, fs, prometheus.WrapRegistererWithPrefix("pyroscopedb_", reg))
 
 	f.blockQuerier = NewBlockQuerier(phlarectx, bucketReader)
 

--- a/pkg/phlaredb/query/metrics.go
+++ b/pkg/phlaredb/query/metrics.go
@@ -21,7 +21,7 @@ type Metrics struct {
 func NewMetrics(reg prometheus.Registerer) *Metrics {
 	m := &Metrics{
 		pageReadsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "phlaredb_page_reads_total",
+			Name: "pyroscopedb_page_reads_total",
 			Help: "Total number of pages read while querying",
 		}, []string{"table", "column"}),
 	}

--- a/pkg/phlaredb/shipper/shipper.go
+++ b/pkg/phlaredb/shipper/shipper.go
@@ -44,23 +44,23 @@ func newMetrics(reg prometheus.Registerer, uploadCompacted bool) *metrics {
 	var m metrics
 
 	m.dirSyncs = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "phlare_shipper_dir_syncs_total",
+		Name: "pyroscope_shipper_dir_syncs_total",
 		Help: "Total number of dir syncs",
 	})
 	m.dirSyncFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "phlare_shipper_dir_sync_failures_total",
+		Name: "pyroscope_shipper_dir_sync_failures_total",
 		Help: "Total number of failed dir syncs",
 	})
 	m.uploads = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "phlare_shipper_uploads_total",
+		Name: "pyroscope_shipper_uploads_total",
 		Help: "Total number of uploaded blocks",
 	})
 	m.uploadFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "phlare_shipper_upload_failures_total",
+		Name: "pyroscope_shipper_upload_failures_total",
 		Help: "Total number of block upload failures",
 	})
 	uploadCompactedGaugeOpts := prometheus.GaugeOpts{
-		Name: "phlare_shipper_upload_compacted_done",
+		Name: "pyroscope_shipper_upload_compacted_done",
 		Help: "If 1 it means shipper uploaded all compacted blocks from the filesystem.",
 	}
 	if uploadCompacted {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -34,7 +34,7 @@ import (
 
 // todo: move to non global metrics.
 var clients = promauto.NewGauge(prometheus.GaugeOpts{
-	Namespace: "phlare",
+	Namespace: "pyroscope",
 	Name:      "querier_ingester_clients",
 	Help:      "The current number of ingester clients.",
 })

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -61,14 +61,14 @@ func newSchedulerProcessor(cfg Config, handler RequestHandler, log log.Logger, r
 		},
 
 		frontendClientRequestDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "phlare_querier_query_frontend_request_duration_seconds",
+			Name:    "pyroscope_querier_query_frontend_request_duration_seconds",
 			Help:    "Time spend doing requests to frontend.",
 			Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
 		}, []string{"operation", "status_code"}),
 	}
 
 	frontendClientsGauge := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Name: "phlare_querier_query_frontend_clients",
+		Name: "pyroscope_querier_query_frontend_clients",
 		Help: "The current number of clients connected to query-frontend.",
 	})
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -125,36 +125,36 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 	}
 
 	s.queueLength = promauto.With(registerer).NewGaugeVec(prometheus.GaugeOpts{
-		Name: "phlare_query_scheduler_queue_length",
+		Name: "pyroscope_query_scheduler_queue_length",
 		Help: "Number of queries in the queue.",
 	}, []string{"tenant"})
 
 	s.cancelledRequests = promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-		Name: "phlare_query_scheduler_cancelled_requests_total",
+		Name: "pyroscope_query_scheduler_cancelled_requests_total",
 		Help: "Total number of query requests that were cancelled after enqueuing.",
 	}, []string{"tenant"})
 	s.discardedRequests = promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-		Name: "phlare_query_scheduler_discarded_requests_total",
+		Name: "pyroscope_query_scheduler_discarded_requests_total",
 		Help: "Total number of query requests discarded.",
 	}, []string{"tenant"})
 	s.requestQueue = queue.NewRequestQueue(cfg.MaxOutstandingPerTenant, cfg.QuerierForgetDelay, s.queueLength, s.discardedRequests)
 
 	s.queueDuration = promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
-		Name:    "phlare_query_scheduler_queue_duration_seconds",
+		Name:    "pyroscope_query_scheduler_queue_duration_seconds",
 		Help:    "Time spend by requests in queue before getting picked up by a querier.",
 		Buckets: prometheus.DefBuckets,
 	})
 	s.connectedQuerierClients = promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "phlare_query_scheduler_connected_querier_clients",
+		Name: "pyroscope_query_scheduler_connected_querier_clients",
 		Help: "Number of querier worker clients currently connected to the query-scheduler.",
 	}, s.requestQueue.GetConnectedQuerierWorkersMetric)
 	s.connectedFrontendClients = promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "phlare_query_scheduler_connected_frontend_clients",
+		Name: "pyroscope_query_scheduler_connected_frontend_clients",
 		Help: "Number of query-frontend worker clients currently connected to the query-scheduler.",
 	}, s.getConnectedFrontendClientsMetric)
 
 	s.inflightRequests = promauto.With(registerer).NewSummary(prometheus.SummaryOpts{
-		Name:       "phlare_query_scheduler_inflight_requests",
+		Name:       "pyroscope_query_scheduler_inflight_requests",
 		Help:       "Number of inflight requests (either queued or processing) sampled at a regular interval. Quantile buckets keep track of inflight requests over the last 60s.",
 		Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.02, 0.8: 0.02, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
 		MaxAge:     time.Minute,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -444,19 +444,19 @@ func TestSchedulerMetrics(t *testing.T) {
 	})
 
 	require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-		# HELP phlare_query_scheduler_queue_length Number of queries in the queue.
-		# TYPE phlare_query_scheduler_queue_length gauge
-		phlare_query_scheduler_queue_length{tenant="another"} 1
-		phlare_query_scheduler_queue_length{tenant="test"} 1
-	`), "phlare_query_scheduler_queue_length"))
+		# HELP pyroscope_query_scheduler_queue_length Number of queries in the queue.
+		# TYPE pyroscope_query_scheduler_queue_length gauge
+		pyroscope_query_scheduler_queue_length{tenant="another"} 1
+		pyroscope_query_scheduler_queue_length{tenant="test"} 1
+	`), "pyroscope_query_scheduler_queue_length"))
 
 	scheduler.cleanupMetricsForInactiveUser("test")
 
 	require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-		# HELP phlare_query_scheduler_queue_length Number of queries in the queue.
-		# TYPE phlare_query_scheduler_queue_length gauge
-		phlare_query_scheduler_queue_length{tenant="another"} 1
-	`), "phlare_query_scheduler_queue_length"))
+		# HELP pyroscope_query_scheduler_queue_length Number of queries in the queue.
+		# TYPE pyroscope_query_scheduler_queue_length gauge
+		pyroscope_query_scheduler_queue_length{tenant="another"} 1
+	`), "pyroscope_query_scheduler_queue_length"))
 }
 
 func initFrontendLoop(t *testing.T, client schedulerpb.SchedulerForFrontendClient, frontendAddr string) schedulerpb.SchedulerForFrontend_FrontendLoopClient {

--- a/pkg/scheduler/schedulerdiscovery/ring.go
+++ b/pkg/scheduler/schedulerdiscovery/ring.go
@@ -113,7 +113,7 @@ func (cfg *RingConfig) ToRingConfig() ring.Config {
 
 // NewRingLifecycler creates a new query-scheduler ring lifecycler with all required lifecycler delegates.
 func NewRingLifecycler(cfg RingConfig, logger log.Logger, reg prometheus.Registerer) (*ring.BasicLifecycler, error) {
-	reg = prometheus.WrapRegistererWithPrefix("phlare_", reg)
+	reg = prometheus.WrapRegistererWithPrefix("pyroscope_", reg)
 	kvStore, err := kv.NewClient(cfg.KVStore, ring.GetCodec(), kv.RegistererWithKVName(reg, "query-scheduler-lifecycler"), logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize query-schedulers' KV store")
@@ -139,7 +139,7 @@ func NewRingLifecycler(cfg RingConfig, logger log.Logger, reg prometheus.Registe
 
 // NewRingClient creates a client for the query-schedulers ring.
 func NewRingClient(cfg RingConfig, component string, logger log.Logger, reg prometheus.Registerer) (*ring.Ring, error) {
-	client, err := ring.New(cfg.ToRingConfig(), component, ringKey, logger, prometheus.WrapRegistererWithPrefix("phlare_", reg))
+	client, err := ring.New(cfg.ToRingConfig(), component, ringKey, logger, prometheus.WrapRegistererWithPrefix("pyroscope_", reg))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize query-schedulers' ring client")
 	}

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// File name for the cluster seed file.
-	ClusterSeedFileName = "phlare_cluster_seed.json"
+	ClusterSeedFileName = "pyroscope_cluster_seed.json"
 	// attemptNumber how many times we will try to read a corrupted cluster seed before deleting it.
 	attemptNumber = 4
 	// seedKey is the key for the cluster seed to use with the kv store.

--- a/pkg/util/recovery.go
+++ b/pkg/util/recovery.go
@@ -17,7 +17,7 @@ const maxStacksize = 8 * 1024
 
 var (
 	panicTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "phlare",
+		Namespace: "pyroscope",
 		Name:      "panic_total",
 		Help:      "The total number of panic triggered",
 	})

--- a/pkg/validation/exporter/exporter.go
+++ b/pkg/validation/exporter/exporter.go
@@ -63,13 +63,13 @@ func NewOverridesExporter(
 		defaultLimits: defaultLimits,
 		tenantLimits:  tenantLimits,
 		overrideDescription: prometheus.NewDesc(
-			"phlare_limits_overrides",
+			"pyroscope_limits_overrides",
 			"Resource limit overrides applied to tenants",
 			[]string{"limit_name", "tenant"},
 			nil,
 		),
 		defaultsDescription: prometheus.NewDesc(
-			"phlare_limits_defaults",
+			"pyroscope_limits_defaults",
 			"Resource limit defaults for tenants without overrides",
 			[]string{"limit_name"},
 			nil,

--- a/pkg/validation/exporter/exporter_test.go
+++ b/pkg/validation/exporter/exporter_test.go
@@ -97,39 +97,39 @@ func TestOverridesExporter_withConfig(t *testing.T) {
 		return rs.Instances[0].Tokens
 	})
 	limitsMetrics := `
-# HELP phlare_limits_overrides Resource limit overrides applied to tenants
-# TYPE phlare_limits_overrides gauge
-phlare_limits_overrides{limit_name="ingestion_rate_mb",tenant="tenant-a"} 10
-phlare_limits_overrides{limit_name="ingestion_burst_size_mb",tenant="tenant-a"} 11
-phlare_limits_overrides{limit_name="max_global_series_per_tenant",tenant="tenant-a"} 12
-phlare_limits_overrides{limit_name="max_series_per_tenant",tenant="tenant-a"} 13
-phlare_limits_overrides{limit_name="max_label_name_length",tenant="tenant-a"} 14
-phlare_limits_overrides{limit_name="max_label_value_length",tenant="tenant-a"} 15
-phlare_limits_overrides{limit_name="max_label_names_per_series",tenant="tenant-a"} 16
-phlare_limits_overrides{limit_name="max_query_lookback",tenant="tenant-a"} 17
-phlare_limits_overrides{limit_name="max_query_length",tenant="tenant-a"} 18
-phlare_limits_overrides{limit_name="max_query_parallelism",tenant="tenant-a"} 19
+# HELP pyroscope_limits_overrides Resource limit overrides applied to tenants
+# TYPE pyroscope_limits_overrides gauge
+pyroscope_limits_overrides{limit_name="ingestion_rate_mb",tenant="tenant-a"} 10
+pyroscope_limits_overrides{limit_name="ingestion_burst_size_mb",tenant="tenant-a"} 11
+pyroscope_limits_overrides{limit_name="max_global_series_per_tenant",tenant="tenant-a"} 12
+pyroscope_limits_overrides{limit_name="max_series_per_tenant",tenant="tenant-a"} 13
+pyroscope_limits_overrides{limit_name="max_label_name_length",tenant="tenant-a"} 14
+pyroscope_limits_overrides{limit_name="max_label_value_length",tenant="tenant-a"} 15
+pyroscope_limits_overrides{limit_name="max_label_names_per_series",tenant="tenant-a"} 16
+pyroscope_limits_overrides{limit_name="max_query_lookback",tenant="tenant-a"} 17
+pyroscope_limits_overrides{limit_name="max_query_length",tenant="tenant-a"} 18
+pyroscope_limits_overrides{limit_name="max_query_parallelism",tenant="tenant-a"} 19
 `
 
 	// Make sure each override matches the values from the supplied `Limit`
-	err = testutil.CollectAndCompare(exporter, bytes.NewBufferString(limitsMetrics), "phlare_limits_overrides")
+	err = testutil.CollectAndCompare(exporter, bytes.NewBufferString(limitsMetrics), "pyroscope_limits_overrides")
 	assert.NoError(t, err)
 
 	limitsMetrics = `
-# HELP phlare_limits_defaults Resource limit defaults for tenants without overrides
-# TYPE phlare_limits_defaults gauge
-phlare_limits_defaults{limit_name="ingestion_rate_mb"} 20
-phlare_limits_defaults{limit_name="ingestion_burst_size_mb"} 21
-phlare_limits_defaults{limit_name="max_global_series_per_tenant"} 22
-phlare_limits_defaults{limit_name="max_series_per_tenant"} 23
-phlare_limits_defaults{limit_name="max_label_name_length"} 24
-phlare_limits_defaults{limit_name="max_label_value_length"} 25
-phlare_limits_defaults{limit_name="max_label_names_per_series"} 26
-phlare_limits_defaults{limit_name="max_query_lookback"} 27
-phlare_limits_defaults{limit_name="max_query_length"} 28
-phlare_limits_defaults{limit_name="max_query_parallelism"} 29
+# HELP pyroscope_limits_defaults Resource limit defaults for tenants without overrides
+# TYPE pyroscope_limits_defaults gauge
+pyroscope_limits_defaults{limit_name="ingestion_rate_mb"} 20
+pyroscope_limits_defaults{limit_name="ingestion_burst_size_mb"} 21
+pyroscope_limits_defaults{limit_name="max_global_series_per_tenant"} 22
+pyroscope_limits_defaults{limit_name="max_series_per_tenant"} 23
+pyroscope_limits_defaults{limit_name="max_label_name_length"} 24
+pyroscope_limits_defaults{limit_name="max_label_value_length"} 25
+pyroscope_limits_defaults{limit_name="max_label_names_per_series"} 26
+pyroscope_limits_defaults{limit_name="max_query_lookback"} 27
+pyroscope_limits_defaults{limit_name="max_query_length"} 28
+pyroscope_limits_defaults{limit_name="max_query_parallelism"} 29
 `
-	err = testutil.CollectAndCompare(exporter, bytes.NewBufferString(limitsMetrics), "phlare_limits_defaults")
+	err = testutil.CollectAndCompare(exporter, bytes.NewBufferString(limitsMetrics), "pyroscope_limits_defaults")
 	assert.NoError(t, err)
 }
 
@@ -208,5 +208,5 @@ func TestOverridesExporter_withRing(t *testing.T) {
 }
 
 func hasOverrideMetrics(e1 prometheus.Collector) bool {
-	return testutil.CollectAndCount(e1, "phlare_limits_overrides") > 0
+	return testutil.CollectAndCount(e1, "pyroscope_limits_overrides") > 0
 }

--- a/pkg/validation/exporter/ring.go
+++ b/pkg/validation/exporter/ring.go
@@ -151,7 +151,7 @@ type overridesExporterRing struct {
 
 // newRing creates a new overridesExporterRing from the given configuration.
 func newRing(config RingConfig, logger log.Logger, reg prometheus.Registerer) (*overridesExporterRing, error) {
-	reg = prometheus.WrapRegistererWithPrefix("phlare_", reg)
+	reg = prometheus.WrapRegistererWithPrefix("pyroscope_", reg)
 	kvStore, err := kv.NewClient(
 		config.KVStore,
 		ring.GetCodec(),

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -53,7 +53,7 @@ var (
 	// DiscardedBytes is a metric of the total discarded bytes, by reason.
 	DiscardedBytes = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "phlare",
+			Namespace: "pyroscope",
 			Name:      "discarded_bytes_total",
 			Help:      "The total number of bytes that were discarded.",
 		},
@@ -63,7 +63,7 @@ var (
 	// DiscardedProfiles is a metric of the number of discarded profiles, by reason.
 	DiscardedProfiles = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "phlare",
+			Namespace: "pyroscope",
 			Name:      "discarded_samples_total",
 			Help:      "The total number of samples that were discarded.",
 		},


### PR DESCRIPTION
This is a breaking change for all dashboards and rules.

In some future we plan to rename the project from Phlare to Pyroscope, so we rather take this hit early.