### PR TITLE
fix: max nodes check

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -266,7 +266,7 @@ func (q *Querier) SelectMergeStacktraces(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, err
 	}
-	if *req.Msg.MaxNodes == 0 {
+	if req.Msg.MaxNodes == nil || *req.Msg.MaxNodes == 0 {
 		mn := maxNodesDefault
 		req.Msg.MaxNodes = &mn
 	}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -266,7 +266,7 @@ func (q *Querier) SelectMergeStacktraces(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, err
 	}
-	if req.Msg.MaxNodes == nil {
+	if *req.Msg.MaxNodes == 0 {
 		mn := maxNodesDefault
 		req.Msg.MaxNodes = &mn
 	}


### PR DESCRIPTION
I don't fully understand this part, but it seems the value is never null, but a 0 value, hence making the check wrong and breaking tree truncation (https://github.com/grafana/phlare/pull/634) and generating a panic [here](https://github.com/grafana/phlare/blob/ae47e35de8af0e959d04c3430cd1e87f75766ae6/pkg/querier/flamegraph.go#L181).