### PR TITLE
Use binary search in `getSeriesIndex` 2.0

### DIFF
--- a/pkg/phlaredb/profiles.go
+++ b/pkg/phlaredb/profiles.go
@@ -41,14 +41,25 @@ type rowRangeWithSeriesIndex struct {
 type rowRangesWithSeriesIndex []rowRangeWithSeriesIndex
 
 func (s rowRangesWithSeriesIndex) getSeriesIndex(rowNum int64) uint32 {
-	// todo: binary search
-	for _, rg := range s {
-		// it is possible that the series is not existing
-		if rg.rowRange == nil {
-			continue
+	l, r := 0, len(s)-1
+outer:
+	for l <= r {
+		mid := (l + r) / 2
+		// when mid is nil go the next element, if we are at the end, take original mid - 1 as upper limit
+		for s[mid].rowRange == nil {
+			mid += 1
+			if mid > r {
+				r = ((l + r) / 2) - 1
+				continue outer
+			}
 		}
-		if rg.rowNum <= rowNum && rg.rowNum+int64(rg.length) > rowNum {
-			return rg.seriesIndex
+		if s[mid].rowNum <= rowNum && s[mid].rowNum+int64(s[mid].length) > rowNum {
+			return s[mid].seriesIndex
+		}
+		if s[mid].rowNum > rowNum {
+			r = mid - 1
+		} else {
+			l = mid + 1
 		}
 	}
 	panic("series index not found")

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -190,9 +190,9 @@ func FromProfile(p *profile.Profile) (*profilev1.Profile, error) {
 		r.Mapping = append(r.Mapping, &profilev1.Mapping{
 			Id:              m.ID,
 			Filename:        addString(strings, m.File),
-			MemoryStart:     (m.Start),
-			MemoryLimit:     (m.Limit),
-			FileOffset:      (m.Offset),
+			MemoryStart:     m.Start,
+			MemoryLimit:     m.Limit,
+			FileOffset:      m.Offset,
 			BuildId:         addString(strings, m.BuildID),
 			HasFunctions:    m.HasFunctions,
 			HasFilenames:    m.HasFilenames,


### PR DESCRIPTION
This brings back the original pr #621, with the fix for the panic.

It makes the code quite a bit more complicated at best with questionable performance gains.


I have also submitted #659 which adds test cases to cover the actual regression.

@hi-rustin how are you feeling about not merging this