### PR TITLE
ci: run 'make fmt check' concurrently

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19.8
+      - name: Format
+        run: make fmt check/unstaged-changes
   test:
     runs-on: ubuntu-latest
     steps:
@@ -25,8 +36,6 @@ jobs:
           go-version: 1.19.8
       - name: Go Mod
         run: make check/go/mod
-      - name: Format
-        run: make fmt check/unstaged-changes
       - name: Test
         run: make go/test
 


### PR DESCRIPTION
format step takes ~7 minutes and tests take ~7 minutes, running them serially is quite slow

For reference:

Before:
![image](https://user-images.githubusercontent.com/6951209/235873037-78bd8c81-672c-4d51-aeda-21c1456c475e.png)

After:
![image](https://user-images.githubusercontent.com/6951209/235873128-bbb811c1-0205-46a7-bdb3-540451b8eebf.png)

