### PR TITLE
Fix concurrent use of LabelValuesRequest and LabelNamesRequest

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -146,7 +146,10 @@ func (q *Querier) LabelValues(ctx context.Context, req *connect.Request[typesv1.
 		sp.Finish()
 	}()
 	responses, err := forAllIngesters(ctx, q.ingesterQuerier, func(childCtx context.Context, ic IngesterQueryClient) ([]string, error) {
-		res, err := ic.LabelValues(childCtx, req)
+		res, err := ic.LabelValues(childCtx, connect.NewRequest(&typesv1.LabelValuesRequest{
+			Name:     req.Msg.Name,
+			Matchers: req.Msg.Matchers,
+		}))
 		if err != nil {
 			return nil, err
 		}
@@ -165,7 +168,9 @@ func (q *Querier) LabelNames(ctx context.Context, req *connect.Request[typesv1.L
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "LabelNames")
 	defer sp.Finish()
 	responses, err := forAllIngesters(ctx, q.ingesterQuerier, func(childCtx context.Context, ic IngesterQueryClient) ([]string, error) {
-		res, err := ic.LabelNames(childCtx, req)
+		res, err := ic.LabelNames(childCtx, connect.NewRequest(&typesv1.LabelNamesRequest{
+			Matchers: req.Msg.Matchers,
+		}))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
It was reported that querier panics on `LabelNames` request. A sample stack trace:
```
2023-05-08T15:11:38Z	fatal error: concurrent map writes
2023-05-08T15:11:38Z	
2023-05-08T15:11:38Z	goroutine 8627 [running]:
2023-05-08T15:11:38Z	github.com/bufbuild/connect-go.(*connectClient).WriteRequestHeader(0xc0002b6980, 0x0, 0x479b09?)
2023-05-08T15:11:38Z		github.com/bufbuild/connect-go@v1.4.1/protocol_connect.go:248 +0x1b8
2023-05-08T15:11:38Z	github.com/bufbuild/connect-go.NewClient[...].func2(0xc000ccd3b0)
2023-05-08T15:11:38Z		github.com/bufbuild/connect-go@v1.4.1/client.go:102 +0x12c
2023-05-08T15:11:38Z	github.com/bufbuild/connect-go.(*Client[...]).CallUnary(0x2bb5a12?, {0x4a7e820?, 0xc0005ba900?}, 0x40a7cd?)
2023-05-08T15:11:38Z		github.com/bufbuild/connect-go@v1.4.1/client.go:121 +0x50
2023-05-08T15:11:38Z	github.com/grafana/phlare/api/gen/proto/go/ingester/v1/ingesterv1connect.(*ingesterServiceClient).LabelNames(0x18f73bba00000000?, {0x4a7e820?, 0xc0005ba900?}, 0x0?)
2023-05-08T15:11:38Z		github.com/grafana/phlare/api/gen/proto/go/ingester/v1/ingesterv1connect/ingester.connect.go:126 +0x3a
2023-05-08T15:11:38Z	github.com/grafana/phlare/pkg/querier.(*Querier).LabelNames.func1({0x4a7e820?, 0xc0005ba900?}, {0x7f7b557bef98?, 0xc0019a5230?})
2023-05-08T15:11:38Z		github.com/grafana/phlare/pkg/querier/querier.go:168 +0x3e
2023-05-08T15:11:38Z	github.com/grafana/phlare/pkg/querier.forGivenIngesters[...].func1(0xc0003249e0)
2023-05-08T15:11:38Z		github.com/grafana/phlare/pkg/querier/ingester_querier.go:66 +0xa3
2023-05-08T15:11:38Z	github.com/grafana/dskit/ring.ReplicationSet.Do.func1(0xfd993d00fd8922?, 0xc0003249e0)
2023-05-08T15:11:38Z		github.com/grafana/dskit@v0.0.0-20230120165636-649501dde2ca/ring/replication_set.go:62 +0x1ae
2023-05-08T15:11:38Z	created by github.com/grafana/dskit/ring.ReplicationSet.Do
2023-05-08T15:11:38Z		github.com/grafana/dskit@v0.0.0-20230120165636-649501dde2ca/ring/replication_set.go:50 +0x2ba
2023-05-08T15:11:38Z
```