### PR TITLE
chore: get latest pyroscope-oss code

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@szhsin/react-menu": "3.5.2",
     "graphviz-react": "^1.2.5",
     "jquery": "^3.6.4",
-    "pyroscope-oss": "git+https://github.com/pyroscope-io/pyroscope.git#72e54cc",
+    "pyroscope-oss": "git+https://github.com/pyroscope-io/pyroscope.git#f710852",
     "react": "^18.2.0",
     "react-datepicker": "^4.7.0",
     "react-debounce-input": "^3.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12010,9 +12010,9 @@ pure-rand@^6.0.0:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.1.tgz#31207dddd15d43f299fdcdb2f572df65030c19af"
   integrity sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==
 
-"pyroscope-oss@git+https://github.com/pyroscope-io/pyroscope.git#72e54cc":
+"pyroscope-oss@git+https://github.com/pyroscope-io/pyroscope.git#f710852":
   version "0.37.2"
-  resolved "git+https://github.com/pyroscope-io/pyroscope.git#72e54ccfcbb4812f87f8fc6840545079096c5462"
+  resolved "git+https://github.com/pyroscope-io/pyroscope.git#f710852d6c8b7b68c9dc3c06d0afae647dc0aa16"
   dependencies:
     "@babel/plugin-transform-runtime" "^7.16.4"
     "@babel/preset-env" "^7.10.4"


### PR DESCRIPTION
Mostly performance upgrades from here https://github.com/grafana/pyroscope/pull/1957