### PR TITLE
Fix stacktrace tree min value counting

### DIFF
--- a/pkg/model/stacktraces.go
+++ b/pkg/model/stacktraces.go
@@ -347,26 +347,25 @@ func (t *stacktraceTree) insert(stack []int32, v int64) {
 
 // minValue returns the minimum "total" value a node in a tree has to have.
 func (t *stacktraceTree) minValue(maxNodes int64) int64 {
-	if maxNodes <= 0 || maxNodes >= int64(len(t.nodes)) {
+	if maxNodes < 1 || maxNodes >= int64(len(t.nodes)) {
 		return 0
 	}
 	s := make(minHeap, 0, maxNodes)
-	mh := &s
-	heap.Init(mh)
+	h := &s
 	for _, n := range t.nodes {
-		if n.total == 0 {
-			continue
+		if h.Len() >= int(maxNodes) {
+			if n.total > (*h)[0] {
+				heap.Pop(h)
+			} else {
+				continue
+			}
 		}
-		if mh.Len() < int(maxNodes) {
-			heap.Push(mh, n.total)
-			continue
-		}
-		if n.total > (*mh)[0] {
-			heap.Pop(mh)
-			heap.Push(mh, n.total)
-		}
+		heap.Push(h, n.total)
 	}
-	return (*mh)[0]
+	if h.Len() < int(maxNodes) {
+		return 0
+	}
+	return (*h)[0]
 }
 
 const lostDuringSerializationNameReference = -1

--- a/pkg/model/stacktraces_test.go
+++ b/pkg/model/stacktraces_test.go
@@ -127,6 +127,7 @@ func TestStackTraceMerger(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		in       []*ingestv1.MergeProfilesStacktracesResult
+		maxNodes int64
 		expected *Tree
 	}{
 		{
@@ -201,6 +202,51 @@ func TestStackTraceMerger(t *testing.T) {
 				{locations: []string{"stack", "other", "my"}, value: 6},
 			}),
 		},
+		{
+			name:     "multiple with truncation",
+			maxNodes: 3,
+			in: []*ingestv1.MergeProfilesStacktracesResult{
+				{
+					Stacktraces: []*ingestv1.StacktraceSample{
+						{
+							FunctionIds: []int32{1, 0},
+							Value:       1,
+						},
+						{
+							FunctionIds: []int32{2, 1, 0},
+							Value:       3,
+						},
+						{
+							FunctionIds: []int32{3},
+							Value:       4,
+						},
+					},
+					FunctionNames: []string{"my", "qux", "stack", "foo"},
+				},
+				{
+					Stacktraces: []*ingestv1.StacktraceSample{
+						{
+							FunctionIds: []int32{1, 0},
+							Value:       1,
+						},
+						{
+							FunctionIds: []int32{2, 1, 0},
+							Value:       3,
+						},
+						{
+							FunctionIds: []int32{3},
+							Value:       5,
+						},
+					},
+					FunctionNames: []string{"my", "qux", "stack", "bar"},
+				},
+			},
+			expected: newTree([]stacktraces{
+				{locations: []string{"other"}, value: 9},
+				{locations: []string{"qux", "my"}, value: 2},
+				{locations: []string{"stack", "qux", "my"}, value: 6},
+			}),
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -208,7 +254,7 @@ func TestStackTraceMerger(t *testing.T) {
 			for _, x := range tc.in {
 				m.MergeStackTraces(x.Stacktraces, x.FunctionNames)
 			}
-			yn := m.TreeBytes(-1)
+			yn := m.TreeBytes(tc.maxNodes)
 			actual, err := UnmarshalTree(yn)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected.String(), actual.String())

--- a/pkg/model/tree.go
+++ b/pkg/model/tree.go
@@ -126,7 +126,7 @@ func (n *node) insert(name string) *node {
 // minValue returns the minimum "total" value a node in a tree has to have to show up in
 // the resulting flamegraph
 func (t *Tree) minValue(maxNodes int64) int64 {
-	if maxNodes == -1 { // -1 means show all nodes
+	if maxNodes < 1 {
 		return 0
 	}
 


### PR DESCRIPTION
In certain cases an attempt to find the min value for a tree causes panic