### PR TITLE
fix: filter out labelsset without the required labels instead of crashing

### DIFF
--- a/public/app/overrides/models/app.ts
+++ b/public/app/overrides/models/app.ts
@@ -1,11 +1,14 @@
 import { parse, brandQuery, Query } from '@webapp/models/query';
 import { z } from 'zod';
 
+export const PyroscopeAppLabel = 'pyroscope_app';
+export const ServiceNameLabel = 'service_name';
+
 const AppWithPyroscopeAppIndex = z.object({
   __profile_type__: z.string(),
   pyroscope_app: z.string(),
   // Fake a discriminated union
-  __name_id__: z.enum(['pyroscope_app']).default('pyroscope_app'),
+  __name_id__: z.enum([PyroscopeAppLabel]).default(PyroscopeAppLabel),
   name: z.string().optional().default(''),
 });
 
@@ -13,7 +16,7 @@ const AppWithServiceNameIndex = z.object({
   __profile_type__: z.string(),
   service_name: z.string(),
   // Fake a discriminated union
-  __name_id__: z.enum(['service_name']).default('service_name'),
+  __name_id__: z.enum([ServiceNameLabel]).default(ServiceNameLabel),
   name: z.string().optional().default(''),
 });
 

--- a/public/app/overrides/services/apps.spec.ts
+++ b/public/app/overrides/services/apps.spec.ts
@@ -887,4 +887,30 @@ describe('appsService', () => {
       },
     ]);
   });
+
+  it('filters out flagSets without pyroscope_app nor service_name', async () => {
+    const spy = jest.spyOn(base, 'requestWithOrgID');
+    const mockData = {
+      labelsSet: [
+        {
+          labels: [],
+        },
+        {
+          labels: [
+            {
+              name: '__profile_type__',
+              value: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
+            },
+            { name: '__type__', value: 'cpu' },
+            { name: '__name__', value: 'process_cpu' },
+          ],
+        },
+      ],
+    };
+    spy.mockReturnValue(Promise.resolve(Result.ok(mockData)));
+
+    const res = await fetchApps();
+    expect(res.isOk).toBe(true);
+    expect(res.value).toEqual([]);
+  });
 });


### PR DESCRIPTION
Apparently it's possible to have labelSets that don't have neither `pyroscope_app` nor `service_name`
![image (7)](https://github.com/grafana/phlare/assets/6951209/36b383b0-06f6-4bd4-95cd-f977392b6749)
