### PR TITLE
fix: routing

### DIFF
--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -26,4 +26,34 @@ describe('smoke', () => {
     cy.visit('/comparison-diff');
     cy.wait(`@profileTypes`);
   });
+
+  it('changes path when navigating', () => {
+    const clickSidebar = (name: string) => {
+      cy.get('nav.pro-menu .pro-item-content')
+        .filter(`:contains("${name}")`)
+        .parent()
+        .parent()
+        .click();
+    };
+
+    cy.visit('/');
+    cy.url().should('contain', '/');
+    cy.title().should('include', 'Single');
+
+    clickSidebar('Comparison View');
+    cy.url().should('contain', '/comparison');
+    cy.title().should('include', 'Comparison');
+
+    clickSidebar('Diff View');
+    cy.url().should('contain', '/comparison-diff');
+    cy.title().should('include', 'Diff');
+
+    clickSidebar('Tag Explorer');
+    cy.url().should('contain', '/explore');
+    cy.title().should('include', 'Tag Explorer');
+
+    clickSidebar('Single');
+    cy.url().should('contain', '/');
+    cy.title().should('include', 'Single');
+  });
 });

--- a/public/app/app.tsx
+++ b/public/app/app.tsx
@@ -7,8 +7,6 @@ import '@webapp/../sass/profile.scss';
 import '@szhsin/react-menu/dist/index.css';
 import Notifications from '@webapp/ui/Notifications';
 import { Router, Switch, Route } from 'react-router-dom';
-import { createBrowserHistory } from 'history';
-
 import { ROUTES } from '@phlare/pages/routes';
 import { SingleView } from '@phlare/pages/SingleView';
 import { ComparisonView } from '@phlare/pages/ComparisonView';
@@ -16,14 +14,13 @@ import { ExploreView } from '@phlare/pages/ExploreView';
 import { DiffView } from '@phlare/pages/DiffView';
 import { Sidebar } from '@phlare/components/Sidebar';
 import { TenantWall } from '@phlare/components/TenantWall';
-import { baseurl } from '@webapp/util/baseurl';
+import { history } from '@phlare/util/history';
 import { useSelectFirstApp } from '@phlare/hooks/useAppNames';
 
 const container = document.getElementById('reactRoot') as HTMLElement;
 const root = ReactDOM.createRoot(container);
 
 function App() {
-  const history = createBrowserHistory({ basename: baseurl() });
   useSelectFirstApp();
 
   return (

--- a/public/app/redux/store.ts
+++ b/public/app/redux/store.ts
@@ -10,8 +10,7 @@ import {
 } from 'redux-persist';
 import ReduxQuerySync from 'redux-query-sync';
 import { configureStore, combineReducers, Middleware } from '@reduxjs/toolkit';
-
-import history from '@webapp/util/history';
+import { history } from '@phlare/util/history';
 
 import continuousReducer, {
   actions as continuousActions,

--- a/public/app/util/history.ts
+++ b/public/app/util/history.ts
@@ -1,0 +1,9 @@
+import { createBrowserHistory } from 'history';
+import { baseurl } from '@webapp/util/baseurl';
+
+// We share the same instance since react-query-sync expects the same
+// 'history' instance to be shared
+// https://github.com/Treora/redux-query-sync/blob/2a2d08e92b2bf931196f97fdbffb0c5ccfb9b6c9/Readme.md?plain=1#L126
+export const history = createBrowserHistory({
+  basename: baseurl(),
+});


### PR DESCRIPTION
Closes https://github.com/grafana/phlare/issues/722

Funnily enough I couldn't reproduce in CI, but trust me ~bro~, the issue is indeed happening.

But basically for `redux-query-sync` to work, the same `history` instance needs to be shared across the app. Didn't dive too deep, but it was affecting how other components that use the `useLocation` were rendered. Basically `Sidebar` wouldn't rerender when the route changes, therefore its navigation items wouldn't include the query parameter!