### PR TITLE
ci: [e2e] wait for /ready instead of hitting the ui directly

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
-          wait-on: http://localhost:4100/ui/
+          wait-on: http://localhost:4100/ready
           start: make run
           config-file: cypress/ci.ts
         env:
@@ -64,7 +64,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
-          wait-on: http://localhost:8080/foobar/
+          wait-on: http://localhost:8080/foobar/ready
           start: |
             make run PARAMS=-api.base-url=/foobar/
           config-file: cypress/ci-base-path.ts

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -168,6 +168,9 @@ func NewFrontend(cfg Config, limits Limits, log log.Logger, reg prometheus.Regis
 }
 
 func (f *Frontend) starting(ctx context.Context) error {
+	// Artificial delay
+	time.Sleep(time.Second * 60)
+
 	f.schedulerWorkersWatcher.WatchService(f.schedulerWorkers)
 
 	return errors.Wrap(services.StartAndAwaitRunning(ctx, f.schedulerWorkers), "failed to start frontend scheduler workers")

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -168,9 +168,6 @@ func NewFrontend(cfg Config, limits Limits, log log.Logger, reg prometheus.Regis
 }
 
 func (f *Frontend) starting(ctx context.Context) error {
-	// Artificial delay
-	time.Sleep(time.Second * 60)
-
 	f.schedulerWorkersWatcher.WatchService(f.schedulerWorkers)
 
 	return errors.Wrap(services.StartAndAwaitRunning(ctx, f.schedulerWorkers), "failed to start frontend scheduler workers")


### PR DESCRIPTION
Closes https://github.com/grafana/phlare/issues/727

It waits on `/ready` instead of hitting `/ui`. There's still a chance that we try to run tests while the query-frontend is being initialized, but it's already a better heuristic than simply hitting the /ui.