### PR TITLE
Increase parquet writer PageBufferSize

### DIFF
--- a/pkg/phlaredb/deduplicating_slice.go
+++ b/pkg/phlaredb/deduplicating_slice.go
@@ -70,6 +70,7 @@ func (s *deduplicatingSlice[M, K, H, P]) Init(path string, cfg *ParquetConfig, m
 	s.writer = parquet.NewGenericWriter[P](file, s.persister.Schema(),
 		parquet.ColumnPageBuffers(parquet.NewFileBufferPool(os.TempDir(), "phlaredb-parquet-buffers*")),
 		parquet.CreatedBy("github.com/grafana/phlare/", build.Version, build.Revision),
+		parquet.PageBufferSize(5*1024*1024),
 	)
 	s.lookup = make(map[K]int64)
 	return nil

--- a/pkg/phlaredb/deduplicating_slice.go
+++ b/pkg/phlaredb/deduplicating_slice.go
@@ -70,7 +70,7 @@ func (s *deduplicatingSlice[M, K, H, P]) Init(path string, cfg *ParquetConfig, m
 	s.writer = parquet.NewGenericWriter[P](file, s.persister.Schema(),
 		parquet.ColumnPageBuffers(parquet.NewFileBufferPool(os.TempDir(), "phlaredb-parquet-buffers*")),
 		parquet.CreatedBy("github.com/grafana/phlare/", build.Version, build.Revision),
-		parquet.PageBufferSize(5*1024*1024),
+		parquet.PageBufferSize(2*1024*1024),
 	)
 	s.lookup = make(map[K]int64)
 	return nil

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -68,7 +68,7 @@ func newProfileStore(phlarectx context.Context) *profileStore {
 	s.writer = parquet.NewGenericWriter[*schemav1.Profile](io.Discard, s.persister.Schema(),
 		parquet.ColumnPageBuffers(parquet.NewFileBufferPool(os.TempDir(), "phlaredb-parquet-buffers*")),
 		parquet.CreatedBy("github.com/grafana/phlare/", build.Version, build.Revision),
-		parquet.PageBufferSize(5*1024*1024),
+		parquet.PageBufferSize(2*1024*1024),
 	)
 
 	return s

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -68,6 +68,7 @@ func newProfileStore(phlarectx context.Context) *profileStore {
 	s.writer = parquet.NewGenericWriter[*schemav1.Profile](io.Discard, s.persister.Schema(),
 		parquet.ColumnPageBuffers(parquet.NewFileBufferPool(os.TempDir(), "phlaredb-parquet-buffers*")),
 		parquet.CreatedBy("github.com/grafana/phlare/", build.Version, build.Revision),
+		parquet.PageBufferSize(5*1024*1024),
 	)
 
 	return s


### PR DESCRIPTION
Our page size is very small and probably not great for remote reads.

Before

```
+--------------------------------------------------+----------------------+----------+---------------------+-----------------------+-------------+-------+-----------+-------------+
|                       COL                        |         TYPE         |  NUMVAL  | TOTALCOMPRESSEDSIZE | TOTALUNCOMPRESSEDSIZE | COMPRESSION |   %   | PAGECOUNT | AVGPAGESIZE |
+--------------------------------------------------+----------------------+----------+---------------------+-----------------------+-------------+-------+-----------+-------------+
| ID                                               | FIXED_LEN_BYTE_ARRAY |   100000 | 1.6 MB              | 1.6 MB                |        0.00 |  1.68 |         7 | 229 kB      |
| SeriesIndex                                      | INT32                |   100000 | 13 kB               | 13 kB                 |        0.00 |  0.01 |         2 | 6.2 kB      |
| Samples/list/element/StacktraceID                | INT64                | 21476381 | 42 MB               | 42 MB                 |        0.00 | 43.91 |       572 | 68 kB       |
| Samples/list/element/Value                       | INT64                | 21476381 | 48 MB               | 48 MB                 |        0.00 | 50.42 |       572 | 86 kB       |
| Samples/list/element/Labels/list/element/Key     | INT64                | 21476381 | 571 kB              | 571 kB                |        0.00 |  0.60 |       157 | 3.7 kB      |
| Samples/list/element/Labels/list/element/Str     | INT64                | 21476381 | 571 kB              | 571 kB                |        0.00 |  0.60 |       157 | 3.7 kB      |
| Samples/list/element/Labels/list/element/Num     | INT64                | 21476381 | 571 kB              | 571 kB                |        0.00 |  0.60 |       157 | 3.7 kB      |
| Samples/list/element/Labels/list/element/NumUnit | INT64                | 21476381 | 571 kB              | 571 kB                |        0.00 |  0.60 |       157 | 3.7 kB      |
| DropFrames                                       | INT64                |   100000 | 89 B                | 89 B                  |        0.00 |  0.00 |         2 | 45 B        |
| KeepFrames                                       | INT64                |   100000 | 89 B                | 89 B                  |        0.00 |  0.00 |         2 | 45 B        |
| TimeNanos                                        | INT64                |   100000 | 800 kB              | 800 kB                |        0.00 |  0.84 |         4 | 200 kB      |
| DurationNanos                                    | INT64                |   100000 | 248 kB              | 248 kB                |        0.00 |  0.26 |         3 | 76 kB       |
| Period                                           | INT64                |   100000 | 80 B                | 80 B                  |        0.00 |  0.00 |         2 | 40 B        |
| Comments/list/element                            | INT64                |   100000 | 196 B               | 196 B                 |        0.00 |  0.00 |         4 | 50 B        |
| DefaultSampleType                                | INT64                |   100000 | 443 kB              | 443 kB                |        0.00 |  0.47 |         4 | 115 kB      |
+--------------------------------------------------+----------------------+----------+---------------------+-----------------------+-------------+-------+-----------+-------------+
```

After

```
+--------------------------------------------------+----------------------+----------+---------------------+-----------------------+-------------+-------+-----------+-------------+
|                       COL                        |         TYPE         |  NUMVAL  | TOTALCOMPRESSEDSIZE | TOTALUNCOMPRESSEDSIZE | COMPRESSION |   %   | PAGECOUNT | AVGPAGESIZE |
+--------------------------------------------------+----------------------+----------+---------------------+-----------------------+-------------+-------+-----------+-------------+
| ID                                               | FIXED_LEN_BYTE_ARRAY |   100000 | 1.6 MB              | 1.6 MB                |        0.00 |  1.68 |         1 | 1.6 MB      |
| SeriesIndex                                      | INT32                |   100000 | 13 kB               | 13 kB                 |        0.00 |  0.01 |         1 | 12 kB       |
| Samples/list/element/StacktraceID                | INT64                | 21476381 | 42 MB               | 42 MB                 |        0.00 | 43.92 |        42 | 922 kB      |
| Samples/list/element/Value                       | INT64                | 21476381 | 48 MB               | 48 MB                 |        0.00 | 50.44 |        42 | 1.2 MB      |
| Samples/list/element/Labels/list/element/Key     | INT64                | 21476381 | 565 kB              | 565 kB                |        0.00 |  0.59 |         9 | 63 kB       |
| Samples/list/element/Labels/list/element/Str     | INT64                | 21476381 | 565 kB              | 565 kB                |        0.00 |  0.59 |         9 | 63 kB       |
| Samples/list/element/Labels/list/element/Num     | INT64                | 21476381 | 565 kB              | 565 kB                |        0.00 |  0.59 |         9 | 63 kB       |
| Samples/list/element/Labels/list/element/NumUnit | INT64                | 21476381 | 565 kB              | 565 kB                |        0.00 |  0.59 |         9 | 63 kB       |
| DropFrames                                       | INT64                |   100000 | 43 B                | 43 B                  |        0.00 |  0.00 |         1 | 43 B        |
| KeepFrames                                       | INT64                |   100000 | 43 B                | 43 B                  |        0.00 |  0.00 |         1 | 43 B        |
| TimeNanos                                        | INT64                |   100000 | 800 kB              | 800 kB                |        0.00 |  0.84 |         1 | 800 kB      |
| DurationNanos                                    | INT64                |   100000 | 248 kB              | 248 kB                |        0.00 |  0.26 |         1 | 228 kB      |
| Period                                           | INT64                |   100000 | 38 B                | 38 B                  |        0.00 |  0.00 |         1 | 38 B        |
| Comments/list/element                            | INT64                |   100000 | 47 B                | 47 B                  |        0.00 |  0.00 |         1 | 47 B        |
| DefaultSampleType                                | INT64                |   100000 | 443 kB              | 443 kB                |        0.00 |  0.47 |         1 | 460 kB      |
+--------------------------------------------------+----------------------+----------+---------------------+-----------------------+-------------+-------+-----------+-------------+
```