### PR TITLE
Free profile objects when cutting a row group

### DIFF
--- a/pkg/phlaredb/profiles.go
+++ b/pkg/phlaredb/profiles.go
@@ -459,6 +459,10 @@ func (pl *profilesIndex) cutRowGroup(rgProfiles []*schemav1.Profile) error {
 
 	for _, ps := range pl.profilesPerFP {
 		// empty all in memory profiles
+		for i := range ps.profiles {
+			// Allow GC to evict the object.
+			ps.profiles[i] = nil
+		}
 		ps.profiles = ps.profiles[:0]
 
 		// attach rowGroup and rowNum information


### PR DESCRIPTION
The PR causes profile store to release profile objects when a new row group is flushed on disk. Currently, objects remain in memory and are not eligible for garbage collection.

Memory consumption of the ingester service has a rather interesting pattern:

Heap In-use (as reported by pprof):
![image](https://github.com/grafana/phlare/assets/12090599/c1a529da-4390-4225-ac38-dadd69b6f5be)

In-use objects:
![image](https://github.com/grafana/phlare/assets/12090599/f8cccd52-5f20-4926-9224-6776b11ef00d)

Where a half of the capacity is taken by `convertSamples`
<img width="1691" alt="image" src="https://github.com/grafana/phlare/assets/12090599/e2a9f8a1-20fc-4406-8931-c76cd9fdd823">

Notice that once a new head is created, memory consumption goes to zero and then grows to ~50% of the max within the next 15-20 minutes. Supposedly, the trend indicates how samples are accumulated. However, I find it interesting that there's another "half": main contributors here are the stacktraces in-memory slice and in-memory parquet readers (that is not supposed to occupy so much memory as it only reads locations, strings, mappings, functions). Nevertheless, this is a different issue we may want to look into