### PR TITLE
docs: Update docs for cloud

### DIFF
--- a/docs/sources/configure-client/_index.md
+++ b/docs/sources/configure-client/_index.md
@@ -72,7 +72,7 @@ To get started choose one of the integrations below:
    </tr>
    <tr>
       <td align="center"><a href="https://grafana.com/docs/phlare/latest/configure-client/grafana-agent/"><img src="https://github.com/grafana/phlare/assets/23323466/1d81f842-5fa0-415d-8d77-aff175a6266f" width="100px;" alt=""/><br />
-        <b>Grafana Agent (Go Pull Mode)</b></a><br />
+        <b>Grafana Agent<br />(Go Pull Mode)</b></a><br />
           <a href="https://grafana.com/docs/phlare/latest/configure-client/grafana-agent/" title="Documentation">Documentation</a><br />
           <a href="https://github.com/grafana/pyroscope/tree/main/examples/php" title="examples">Examples</a>
       </td>

--- a/docs/sources/configure-client/_index.md
+++ b/docs/sources/configure-client/_index.md
@@ -44,6 +44,11 @@ The decision of which mode to use depends on your specific use case and requirem
 To get started choose one of the integrations below:
 <table>
    <tr>
+      <td align="center"><a href="https://grafana.com/docs/phlare/latest/configure-client/grafana-agent/"><img src="https://github.com/grafana/phlare/assets/23323466/1d81f842-5fa0-415d-8d77-aff175a6266f" width="100px;" alt=""/><br />
+        <b>Grafana Agent<br />(Go Pull Mode)</b></a><br />
+          <a href="https://grafana.com/docs/phlare/latest/configure-client/grafana-agent/" title="Documentation">Documentation</a><br />
+          <a href="https://github.com/grafana/pyroscope/tree/main/examples/php" title="examples">Examples</a>
+      </td>
       <td align="center"><a href="https://grafana.com/docs/phlare/latest/configure-client/language-sdks/go_push/"><img src="https://user-images.githubusercontent.com/23323466/178160549-2d69a325-56ec-4e19-bca7-d460d400b163.png" width="100px;" alt=""/><br />
         <b>Golang</b></a><br />
           <a href="https://grafana.com/docs/phlare/latest/configure-client/language-sdks/go_push/" title="Documentation">Documentation</a><br />
@@ -64,22 +69,17 @@ To get started choose one of the integrations below:
           <a href="https://grafana.com/docs/phlare/latest/configure-client/language-sdks/python/" title="Documentation">Documentation</a><br />
           <a href="https://github.com/grafana/pyroscope/tree/main/examples/python" title="python-examples">Examples</a>
       </td>
-      <td align="center"><a href="https://grafana.com/docs/phlare/latest/configure-client/language-sdks/ruby/"><img src="https://user-images.githubusercontent.com/23323466/178160554-b0be2bc5-8574-4881-ac4c-7977c0b2c195.png" width="100px;" alt=""/><br />
-        <b>Ruby</b></a><br />
-          <a href="https://grafana.com/docs/phlare/latest/configure-client/language-sdks/ruby/" title="Documentation">Documentation</a><br />
-          <a href="https://github.com/grafana/pyroscope/tree/main/examples/ruby" title="ruby-examples">Examples</a>
-      </td>
    </tr>
    <tr>
-      <td align="center"><a href="https://grafana.com/docs/phlare/latest/configure-client/grafana-agent/"><img src="https://github.com/grafana/phlare/assets/23323466/1d81f842-5fa0-415d-8d77-aff175a6266f" width="100px;" alt=""/><br />
-        <b>Grafana Agent<br />(Go Pull Mode)</b></a><br />
-          <a href="https://grafana.com/docs/phlare/latest/configure-client/grafana-agent/" title="Documentation">Documentation</a><br />
-          <a href="https://github.com/grafana/pyroscope/tree/main/examples/php" title="examples">Examples</a>
-      </td>
       <td align="center"><a href="https://grafana.com/docs/phlare/latest/configure-client/language-sdks/dotnet/"><img src="https://user-images.githubusercontent.com/23323466/178160544-d2e189c6-a521-482c-a7dc-5375c1985e24.png" width="100px;" alt=""/><br />
         <b>Dotnet</b></a><br />
           <a href="https://grafana.com/docs/phlare/latest/configure-client/language-sdks/dotnet/" title="Documentation">Documentation</a><br />
           <a href="https://github.com/grafana/pyroscope/tree/main/examples/dotnet" title="examples">Examples</a>
+      </td>
+      <td align="center"><a href="https://grafana.com/docs/phlare/latest/configure-client/language-sdks/ruby/"><img src="https://user-images.githubusercontent.com/23323466/178160554-b0be2bc5-8574-4881-ac4c-7977c0b2c195.png" width="100px;" alt=""/><br />
+        <b>Ruby</b></a><br />
+          <a href="https://grafana.com/docs/phlare/latest/configure-client/language-sdks/ruby/" title="Documentation">Documentation</a><br />
+          <a href="https://github.com/grafana/pyroscope/tree/main/examples/ruby" title="ruby-examples">Examples</a>
       </td>
       <td align="center"><a href="https://grafana.com/docs/phlare/latest/configure-client/language-sdks/nodejs/"><img src="https://user-images.githubusercontent.com/23323466/178160551-a79ee6ff-a5d6-419e-89e6-39047cb08126.png" width="100px;" alt=""/><br />
         <b>NodeJS</b></a><br />

--- a/docs/sources/configure-client/language-sdks/dotnet.md
+++ b/docs/sources/configure-client/language-sdks/dotnet.md
@@ -118,14 +118,7 @@ Here is a simple [example](https://github.com/grafana/pyroscope/blob/main/exampl
 | PYROSCOPE_PROFILING_ALLOCATION_ENABLED | Boolean      | If set to true, enables the Allocations profiling. Defaults to false. |
 | PYROSCOPE_PROFILING_LOCK_ENABLED       | Boolean      | If set to true, enables the Lock Contention profiling. Defaults to false. |
 
-## Sending data into Pyroscope Cloud
-
-1. Set `PYROSCOPE_SERVER_ADDRESS` to `PYROSCOPE_SERVER_ADDRESS=https://ingest.pyroscope.cloud`
-2. Go to [Pyroscope Cloud API Keys page](https://pyroscope.cloud/settings/api-keys)
-3. Copy one of the keys
-4. Add it to your .NET profiler configuration: `PYROSCOPE_AUTH_TOKEN="psx-..."`
-
-## Sending data to Phlare with Pyroscope .NET integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope .NET integration
 
 Starting with [weekly-f8](https://hub.docker.com/r/grafana/phlare/tags) you can ingest pyroscope profiles directly to phlare.
 
@@ -142,9 +135,9 @@ export PYROSCOPE_BASIC_AUTH_PASSWORD=<Password>
 export PYROSCOPE_TENANT_ID=<TenantID>
 ```
 
-To configure .NET integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the grafana.com Phlare URL or your own custom Phlare server URL.
+To configure .NET integration to send data to Grafana Cloud or Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
 
-If you need to send data to grafana.com, you'll have to configure HTTP Basic authentication. Replace `<User>` with your grafana.com stack user and `<Password>` with your grafana.com API key.
+If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafan Cloud API key.
 
 If your Phlare server has multi-tenancy enabled, you'll need to configure a tenant ID. Replace `<TenantID>` with your Phlare tenant ID.
 

--- a/docs/sources/configure-client/language-sdks/dotnet.md
+++ b/docs/sources/configure-client/language-sdks/dotnet.md
@@ -118,7 +118,7 @@ Here is a simple [example](https://github.com/grafana/pyroscope/blob/main/exampl
 | PYROSCOPE_PROFILING_ALLOCATION_ENABLED | Boolean      | If set to true, enables the Allocations profiling. Defaults to false. |
 | PYROSCOPE_PROFILING_LOCK_ENABLED       | Boolean      | If set to true, enables the Lock Contention profiling. Defaults to false. |
 
-## Sending data to Grafana Cloud or Phlare with Pyroscope .NET integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope .NET SDK
 
 Starting with [weekly-f8](https://hub.docker.com/r/grafana/phlare/tags) you can ingest pyroscope profiles directly to phlare.
 
@@ -135,7 +135,7 @@ export PYROSCOPE_BASIC_AUTH_PASSWORD=<Password>
 export PYROSCOPE_TENANT_ID=<TenantID>
 ```
 
-To configure .NET integration to send data to Grafana Cloud or Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
+To configure .NET sdk to send data to Grafana Cloud or Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
 
 If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafan Cloud API key.
 

--- a/docs/sources/configure-client/language-sdks/ebpf.md
+++ b/docs/sources/configure-client/language-sdks/ebpf.md
@@ -78,7 +78,7 @@ All parameters below are also supported as CLI arguments, a full list can be acc
 | `PYROSCOPE_ONLY_SERVICES`     | `false`                             | Ignore processes unknown to service discovery. In a Kubernetes cluster it ignores processes like `containerd, runc, kubelet` etc | 
 | `PYROSCOPE_SYMBOL_CACHE_SIZE` | `256`                          | Max size of symbols cache (1 entry per process). Change this value if you’re experiencing memory pressure or have many individual services. |
 
-## Sending data to Phlare with Pyroscope eBPF integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope eBPF integration
 
 Starting with [weekly-f8](https://hub.docker.com/r/grafana/phlare/tags) you can ingest pyroscope profiles directly to phlare.
 
@@ -91,9 +91,9 @@ Starting with [weekly-f8](https://hub.docker.com/r/grafana/phlare/tags) you can 
   --tenant-id=<TenantID>              \
 ```
 
-To configure eBPF integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the grafana.com Phlare URL or your own custom Phlare server URL.
+To configure eBPF integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
 
-If you need to send data to grafana.com, you'll have to configure HTTP Basic authentication. Replace `<User>` with your grafana.com stack user and `<Password>` with your grafana.com API key.
+If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafana Cloud API key.
 
 If your Phlare server has multi-tenancy enabled, you'll need to configure a tenant ID. Replace `<TenantID>` with your Phlare tenant ID.
 

--- a/docs/sources/configure-client/language-sdks/go_push.md
+++ b/docs/sources/configure-client/language-sdks/go_push.md
@@ -110,7 +110,7 @@ runtime.SetBlockProfileRate(rate)
 
 `rate` parameter controls the fraction of goroutine blocking events that are reported in the blocking profile. The profiler aims to sample an average of one blocking event per rate nanoseconds spent blocked.
 
-## Sending data to Phlare with Pyroscope Golang integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope Golang integration
 
 Starting with [weekly-f8](https://hub.docker.com/r/grafana/phlare/tags) you can ingest pyroscope profiles directly to phlare.
 
@@ -133,9 +133,9 @@ pyroscope.Start(pyroscope.Config{
 })
 ```
 
-To configure the Golang integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the grafana.com Phlare URL or your own custom Phlare server URL.
+To configure the Golang integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
 
-If you need to send data to grafana.com, you'll have to configure HTTP Basic authentication. Replace `<User>` with your grafana.com stack user and `<Password>` with your grafana.com API key.
+If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafana Cloud API key.
 
 If your Phlare server has multi-tenancy enabled, you'll need to configure a tenant ID. Replace `<TenantID>` with your Phlare tenant ID.
 

--- a/docs/sources/configure-client/language-sdks/go_push.md
+++ b/docs/sources/configure-client/language-sdks/go_push.md
@@ -110,7 +110,7 @@ runtime.SetBlockProfileRate(rate)
 
 `rate` parameter controls the fraction of goroutine blocking events that are reported in the blocking profile. The profiler aims to sample an average of one blocking event per rate nanoseconds spent blocked.
 
-## Sending data to Grafana Cloud or Phlare with Pyroscope Golang integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope Golang SDK
 
 Starting with [weekly-f8](https://hub.docker.com/r/grafana/phlare/tags) you can ingest pyroscope profiles directly to phlare.
 
@@ -133,7 +133,7 @@ pyroscope.Start(pyroscope.Config{
 })
 ```
 
-To configure the Golang integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
+To configure the Golang sdk to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
 
 If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafana Cloud API key.
 

--- a/docs/sources/configure-client/language-sdks/java.md
+++ b/docs/sources/configure-client/language-sdks/java.md
@@ -140,11 +140,11 @@ Java integration supports JFR format to be able to support multiple events (JFR 
 |`PYROSCOPE_ALLOC_LIVE`                   |is a boolean value that enables live object profiling when set to true. It is disabled by default.                                                                                                                                                                                                                                                                                          |
 |`PYROSCOPE_GC_BEFORE_DUMP`               |is a boolean value that executes a `System.gc()` command before dumping the profile when set to true. This option may be useful for live profiling, but is disabled by default.                                                                                                                                                                                                             |
 
-## Sending data to Phlare with Pyroscope java integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope java integration
 
-To configure java integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the grafana.com Phlare URL or your own custom Phlare server URL.
+To configure java integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
 
-If you need to send data to grafana.com, you'll have to configure HTTP Basic authentication. Replace `<User>` with your grafana.com stack user and `<Password>` with your grafana.com API key.
+If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafana Cloud API key.
 
 If your Phlare server has multi-tenancy enabled, you'll need to configure a tenant ID. Replace `<TenantID>` with your Phlare tenant ID.
 

--- a/docs/sources/configure-client/language-sdks/java.md
+++ b/docs/sources/configure-client/language-sdks/java.md
@@ -140,9 +140,9 @@ Java integration supports JFR format to be able to support multiple events (JFR 
 |`PYROSCOPE_ALLOC_LIVE`                   |is a boolean value that enables live object profiling when set to true. It is disabled by default.                                                                                                                                                                                                                                                                                          |
 |`PYROSCOPE_GC_BEFORE_DUMP`               |is a boolean value that executes a `System.gc()` command before dumping the profile when set to true. This option may be useful for live profiling, but is disabled by default.                                                                                                                                                                                                             |
 
-## Sending data to Grafana Cloud or Phlare with Pyroscope java integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope java SDK
 
-To configure java integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
+To configure java sdk to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
 
 If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafana Cloud API key.
 

--- a/docs/sources/configure-client/language-sdks/nodejs.md
+++ b/docs/sources/configure-client/language-sdks/nodejs.md
@@ -87,9 +87,9 @@ scrape-configs:
           env: dev
 ```
 
-## Sending data to Grafana Cloud or Phlare with Pyroscope NodeJS integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope NodeJS SDK
 
-To configure NodeJS integration to send data to Phlare, replace the `serverAddress` placeholder with the appropriate server URL. This could be the Grafana Cloud Pyroscope URL or your own custom Phlare server URL.
+To configure NodeJS sdk to send data to Phlare, replace the `serverAddress` placeholder with the appropriate server URL. This could be the Grafana Cloud Pyroscope URL or your own custom Phlare server URL.
 
 If you need to send data to Grafana Cloud, you’ll have to configure HTTP Basic authentication. Replace `basicAuthUser` with your Grafana Cloud stack user ID and `basicAuthPassword` with your Grafana Cloud API key.
 

--- a/docs/sources/configure-client/language-sdks/nodejs.md
+++ b/docs/sources/configure-client/language-sdks/nodejs.md
@@ -87,7 +87,7 @@ scrape-configs:
           env: dev
 ```
 
-## Sending data to Phlare with Pyroscope NodeJS integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope NodeJS integration
 
 To configure NodeJS integration to send data to Phlare, replace the `serverAddress` placeholder with the appropriate server URL. This could be the Grafana Cloud Pyroscope URL or your own custom Phlare server URL.
 

--- a/docs/sources/configure-client/language-sdks/python.md
+++ b/docs/sources/configure-client/language-sdks/python.md
@@ -59,7 +59,7 @@ with pyroscope.tag_wrapper({ "controller": "slow_controller_i_want_to_profile" }
   slow_code()
 ```
 
-## Sending data to Phlare with Pyroscope Python integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope Python integration
 
 Starting with [weekly-f8](https://hub.docker.com/r/grafana/phlare/tags) you can ingest pyroscope profiles directly to phlare.
 
@@ -75,9 +75,9 @@ pyroscope.configure(
 )
 ```
 
-To configure Python integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the grafana.com Phlare URL or your own custom Phlare server URL.
+To configure Python integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
 
-If you need to send data to grafana.com, you'll have to configure HTTP Basic authentication. Replace `<User>` with your grafana.com stack user and `<Password>` with your grafana.com API key.
+If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafana Cloud API key.
 
 If your Phlare server has multi-tenancy enabled, you'll need to configure a tenant ID. Replace `<TenantID>` with your Phlare tenant ID.
 

--- a/docs/sources/configure-client/language-sdks/python.md
+++ b/docs/sources/configure-client/language-sdks/python.md
@@ -59,7 +59,7 @@ with pyroscope.tag_wrapper({ "controller": "slow_controller_i_want_to_profile" }
   slow_code()
 ```
 
-## Sending data to Grafana Cloud or Phlare with Pyroscope Python integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope Python SDK
 
 Starting with [weekly-f8](https://hub.docker.com/r/grafana/phlare/tags) you can ingest pyroscope profiles directly to phlare.
 

--- a/docs/sources/configure-client/language-sdks/python.md
+++ b/docs/sources/configure-client/language-sdks/python.md
@@ -75,7 +75,7 @@ pyroscope.configure(
 )
 ```
 
-To configure Python integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
+To configure Python sdk to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
 
 If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafana Cloud API key.
 

--- a/docs/sources/configure-client/language-sdks/ruby.md
+++ b/docs/sources/configure-client/language-sdks/ruby.md
@@ -68,7 +68,7 @@ Pyroscope.configure do |config|
 end
 ```
 
-## Sending data to Phlare with Pyroscope Ruby integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope Ruby integration
 
 Starting with [weekly-f8](https://hub.docker.com/r/grafana/phlare/tags) you can ingest pyroscope profiles directly to phlare.
 
@@ -84,9 +84,9 @@ Pyroscope.configure do |config|
 end
 ```
 
-To configure Ruby integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the grafana.com Phlare URL or your own custom Phlare server URL.
+To configure Ruby integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
 
-If you need to send data to grafana.com, you'll have to configure HTTP Basic authentication. Replace `<User>` with your grafana.com stack user and `<Password>` with your grafana.com API key.
+If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafana Cloud API key.
 
 If your Phlare server has multi-tenancy enabled, you'll need to configure a tenant ID. Replace `<TenantID>` with your Phlare tenant ID.
 

--- a/docs/sources/configure-client/language-sdks/ruby.md
+++ b/docs/sources/configure-client/language-sdks/ruby.md
@@ -68,7 +68,7 @@ Pyroscope.configure do |config|
 end
 ```
 
-## Sending data to Grafana Cloud or Phlare with Pyroscope Ruby integration
+## Sending data to Grafana Cloud or Phlare with Pyroscope Ruby SDK
 
 Starting with [weekly-f8](https://hub.docker.com/r/grafana/phlare/tags) you can ingest pyroscope profiles directly to phlare.
 

--- a/docs/sources/configure-client/language-sdks/ruby.md
+++ b/docs/sources/configure-client/language-sdks/ruby.md
@@ -84,7 +84,7 @@ Pyroscope.configure do |config|
 end
 ```
 
-To configure Ruby integration to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
+To configure Ruby sdk to send data to Phlare, replace the `<URL>` placeholder with the appropriate server URL. This could be the Grafana Cloud URL or your own custom Phlare server URL.
 
 If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafana Cloud API key.
 


### PR DESCRIPTION
Updates docs for how to send data to phlare or grafana cloud and removes some reference to og-pyroscope cloud

also fixes small ui thing:
![image](https://github.com/grafana/phlare/assets/23323466/2cd7567a-f2ec-441c-a9a9-c5602c06df6a)

