### PR TITLE
Increase goreleaser timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -48,7 +48,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser
           version: latest
-          args: release --clean --skip-publish
+          args: release --clean --skip-publish --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'


### PR DESCRIPTION
On average, the release process takes a little over half an hour (see https://github.com/grafana/phlare/actions/workflows/weekly-release.yml), and the default goreleaser timeout is 30m.

I think it makes sense to increase goreleaser timeout to 60m. Long term we should try to decrease the job duration.
