### PR TITLE
Reduce join_members for memberlist using dns+

### DIFF
--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -628,6 +628,13 @@ storage:
   # CLI flag: -storage.storage-prefix
   [storage_prefix: <string> | default = ""]
 
+self_profiling:
+  # CLI flag: -self-profiling.mutex-profile-fraction
+  [mutex_profile_fraction: <int> | default = 5]
+
+  # CLI flag: -self-profiling.block-profile-rate
+  [block_profile_rate: <int> | default = 5]
+
 # When set to true, incoming HTTP requests must specify tenant ID in HTTP
 # X-Scope-OrgId header. When set to false, tenant ID anonymous is used instead.
 # CLI flag: -auth.multitenancy-enabled

--- a/operations/phlare/helm/phlare/rendered/micro-services.yaml
+++ b/operations/phlare/helm/phlare/rendered/micro-services.yaml
@@ -1565,7 +1565,7 @@ spec:
           args:
             - "-target=agent"
             - "-memberlist.cluster-label=default-phlare-dev"
-            - "-memberlist.join=phlare-dev-memberlist.default.svc.cluster.local."
+            - "-memberlist.join=dns+phlare-dev-memberlist.default.svc.cluster.local.:7946"
             - "-client.url=http://phlare-dev-distributor.default.svc.cluster.local.:4100"
             - "-config.file=/etc/phlare/config.yaml"
             - "-runtime-config.file=/etc/phlare/overrides/overrides.yaml"
@@ -1654,7 +1654,7 @@ spec:
           args:
             - "-target=distributor"
             - "-memberlist.cluster-label=default-phlare-dev"
-            - "-memberlist.join=phlare-dev-memberlist.default.svc.cluster.local."
+            - "-memberlist.join=dns+phlare-dev-memberlist.default.svc.cluster.local.:7946"
             - "-config.file=/etc/phlare/config.yaml"
             - "-runtime-config.file=/etc/phlare/overrides/overrides.yaml"
             - "-log.level=debug"
@@ -1742,7 +1742,7 @@ spec:
           args:
             - "-target=querier"
             - "-memberlist.cluster-label=default-phlare-dev"
-            - "-memberlist.join=phlare-dev-memberlist.default.svc.cluster.local."
+            - "-memberlist.join=dns+phlare-dev-memberlist.default.svc.cluster.local.:7946"
             - "-config.file=/etc/phlare/config.yaml"
             - "-runtime-config.file=/etc/phlare/overrides/overrides.yaml"
             - "-log.level=debug"
@@ -1830,7 +1830,7 @@ spec:
           args:
             - "-target=query-frontend"
             - "-memberlist.cluster-label=default-phlare-dev"
-            - "-memberlist.join=phlare-dev-memberlist.default.svc.cluster.local."
+            - "-memberlist.join=dns+phlare-dev-memberlist.default.svc.cluster.local.:7946"
             - "-config.file=/etc/phlare/config.yaml"
             - "-runtime-config.file=/etc/phlare/overrides/overrides.yaml"
             - "-log.level=debug"
@@ -1918,7 +1918,7 @@ spec:
           args:
             - "-target=query-scheduler"
             - "-memberlist.cluster-label=default-phlare-dev"
-            - "-memberlist.join=phlare-dev-memberlist.default.svc.cluster.local."
+            - "-memberlist.join=dns+phlare-dev-memberlist.default.svc.cluster.local.:7946"
             - "-config.file=/etc/phlare/config.yaml"
             - "-runtime-config.file=/etc/phlare/overrides/overrides.yaml"
             - "-log.level=debug"
@@ -2103,7 +2103,7 @@ spec:
           args:
             - "-target=ingester"
             - "-memberlist.cluster-label=default-phlare-dev"
-            - "-memberlist.join=phlare-dev-memberlist.default.svc.cluster.local."
+            - "-memberlist.join=dns+phlare-dev-memberlist.default.svc.cluster.local.:7946"
             - "-config.file=/etc/phlare/config.yaml"
             - "-runtime-config.file=/etc/phlare/overrides/overrides.yaml"
             - "-log.level=debug"
@@ -2193,7 +2193,7 @@ spec:
           args:
             - "-target=store-gateway"
             - "-memberlist.cluster-label=default-phlare-dev"
-            - "-memberlist.join=phlare-dev-memberlist.default.svc.cluster.local."
+            - "-memberlist.join=dns+phlare-dev-memberlist.default.svc.cluster.local.:7946"
             - "-config.file=/etc/phlare/config.yaml"
             - "-runtime-config.file=/etc/phlare/overrides/overrides.yaml"
             - "-log.level=debug"

--- a/operations/phlare/helm/phlare/rendered/single-binary.yaml
+++ b/operations/phlare/helm/phlare/rendered/single-binary.yaml
@@ -856,7 +856,7 @@ spec:
           args:
             - "-target=all"
             - "-memberlist.cluster-label=default-phlare-dev"
-            - "-memberlist.join=phlare-dev-memberlist.default.svc.cluster.local."
+            - "-memberlist.join=dns+phlare-dev-memberlist.default.svc.cluster.local.:7946"
             - "-config.file=/etc/phlare/config.yaml"
             - "-runtime-config.file=/etc/phlare/overrides/overrides.yaml"
             - "-log.level=debug"

--- a/operations/phlare/helm/phlare/templates/deployments-statefulsets.yaml
+++ b/operations/phlare/helm/phlare/templates/deployments-statefulsets.yaml
@@ -50,7 +50,7 @@ spec:
           args:
             - "-target={{ $component }}"
             - "-memberlist.cluster-label={{ .Release.Namespace }}-{{ include "phlare.fullname" .}}"
-            - "-memberlist.join={{ include "phlare.fullname" .}}-memberlist.{{ .Release.Namespace }}.svc.cluster.local."
+            - "-memberlist.join=dns+{{ include "phlare.fullname" .}}-memberlist.{{ .Release.Namespace }}.svc.cluster.local.:{{ .Values.phlare.memberlist.port }}"
           {{- if eq $component "agent" }}
             - "-client.url=http://{{ include "phlare.fullname" . }}-distributor.{{ .Release.Namespace }}.svc.cluster.local.:{{ $values.service.port }}"
           {{- end }}


### PR DESCRIPTION
This will reduce the number of members to join at startup. Before it would try to join all members, now using `dns+` it will only select a subset.

See https://github.com/grafana/loki/pull/9723