### PR TITLE
Adds __service_name__ labels to improve data locality

### DIFF
--- a/pkg/phlaredb/labels.go
+++ b/pkg/phlaredb/labels.go
@@ -1,0 +1,64 @@
+package phlaredb
+
+import (
+	"fmt"
+	"strings"
+
+	profilev1 "github.com/grafana/phlare/api/gen/proto/go/google/v1"
+	typesv1 "github.com/grafana/phlare/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/phlare/pkg/model"
+	"github.com/prometheus/common/model"
+)
+
+var labelNameServiceName = fmt.Sprintf("__%s__", phlaremodel.LabelNameServiceName)
+
+func labelsForProfile(p *profilev1.Profile, externalLabels ...*typesv1.LabelPair) ([]phlaremodel.Labels, []model.Fingerprint) {
+	// build label set per sample type before references are rewritten
+	var (
+		sb                                             strings.Builder
+		lbls                                           = phlaremodel.NewLabelsBuilder(externalLabels)
+		sampleType, sampleUnit, periodType, periodUnit string
+		metricName                                     = phlaremodel.Labels(externalLabels).Get(model.MetricNameLabel)
+	)
+
+	// Inject into labels the __service_name__ label if it exists
+	// This allows better locality of the data in parquet files (row group are sorted by).
+	if serviceName := lbls.Labels().Get(phlaremodel.LabelNameServiceName); serviceName != "" {
+		lbls.Set(labelNameServiceName, serviceName)
+	}
+
+	// set common labels
+	if p.PeriodType != nil {
+		periodType = p.StringTable[p.PeriodType.Type]
+		lbls.Set(phlaremodel.LabelNamePeriodType, periodType)
+		periodUnit = p.StringTable[p.PeriodType.Unit]
+		lbls.Set(phlaremodel.LabelNamePeriodUnit, periodUnit)
+	}
+
+	profilesLabels := make([]phlaremodel.Labels, len(p.SampleType))
+	seriesRefs := make([]model.Fingerprint, len(p.SampleType))
+	for pos := range p.SampleType {
+		sampleType = p.StringTable[p.SampleType[pos].Type]
+		lbls.Set(phlaremodel.LabelNameType, sampleType)
+		sampleUnit = p.StringTable[p.SampleType[pos].Unit]
+		lbls.Set(phlaremodel.LabelNameUnit, sampleUnit)
+
+		sb.Reset()
+		_, _ = sb.WriteString(metricName)
+		_, _ = sb.WriteRune(':')
+		_, _ = sb.WriteString(sampleType)
+		_, _ = sb.WriteRune(':')
+		_, _ = sb.WriteString(sampleUnit)
+		_, _ = sb.WriteRune(':')
+		_, _ = sb.WriteString(periodType)
+		_, _ = sb.WriteRune(':')
+		_, _ = sb.WriteString(periodUnit)
+		t := sb.String()
+		lbls.Set(phlaremodel.LabelNameProfileType, t)
+		lbs := lbls.Labels().Clone()
+		profilesLabels[pos] = lbs
+		seriesRefs[pos] = model.Fingerprint(lbs.Hash())
+
+	}
+	return profilesLabels, seriesRefs
+}

--- a/pkg/phlaredb/labels_test.go
+++ b/pkg/phlaredb/labels_test.go
@@ -1,0 +1,57 @@
+package phlaredb
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	phlaremodel "github.com/grafana/phlare/pkg/model"
+)
+
+func TestLabelsForProfiles(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		in       phlaremodel.Labels
+		expected phlaremodel.Labels
+	}{
+		{
+			"default",
+			phlaremodel.Labels{{Name: model.MetricNameLabel, Value: "cpu"}},
+			phlaremodel.Labels{
+				{Name: model.MetricNameLabel, Value: "cpu"},
+				{Name: phlaremodel.LabelNameUnit, Value: "unit"},
+				{Name: phlaremodel.LabelNameProfileType, Value: "cpu:type:unit:type:unit"},
+				{Name: phlaremodel.LabelNameType, Value: "type"},
+				{Name: phlaremodel.LabelNamePeriodType, Value: "type"},
+				{Name: phlaremodel.LabelNamePeriodUnit, Value: "unit"},
+			},
+		},
+		{
+			"with service_name",
+			phlaremodel.Labels{
+				{Name: model.MetricNameLabel, Value: "cpu"},
+				{Name: phlaremodel.LabelNameServiceName, Value: "service_name"},
+			},
+			phlaremodel.Labels{
+				{Name: model.MetricNameLabel, Value: "cpu"},
+				{Name: phlaremodel.LabelNameUnit, Value: "unit"},
+				{Name: phlaremodel.LabelNameProfileType, Value: "cpu:type:unit:type:unit"},
+				{Name: phlaremodel.LabelNameType, Value: "type"},
+				{Name: phlaremodel.LabelNamePeriodType, Value: "type"},
+				{Name: phlaremodel.LabelNamePeriodUnit, Value: "unit"},
+				{Name: labelNameServiceName, Value: "service_name"},
+				{Name: phlaremodel.LabelNameServiceName, Value: "service_name"},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			sort.Sort(tt.expected)
+			result, fps := labelsForProfile(newProfileFoo(), tt.in...)
+			require.Equal(t, tt.expected, result[0])
+			require.Equal(t, model.Fingerprint(tt.expected.Hash()), fps[0])
+		})
+	}
+}


### PR DESCRIPTION
This adds a new __service_name__ labels to profiles ingested if they have a `service_name` label.

This is to improve data locality on disk since we order them by series (unique label sets).

I've also move the code for labeling profiles and added tests.

Fixes https://github.com/grafana/phlare/issues/751