### PR TITLE
Increase Count per RowGroup by 2

### DIFF
--- a/pkg/phlaredb/deduplicating_slice.go
+++ b/pkg/phlaredb/deduplicating_slice.go
@@ -23,7 +23,7 @@ var (
 	uint32SlicePool zeropool.Pool[[]uint32]
 
 	defaultParquetConfig = &ParquetConfig{
-		MaxBufferRowCount: 100_000,
+		MaxBufferRowCount: 200_000,
 		MaxRowGroupBytes:  10 * 128 * 1024 * 1024,
 		MaxBlockBytes:     10 * 10 * 128 * 1024 * 1024,
 	}


### PR DESCRIPTION
Since we now can ingest more data in memory, we should try to avoid cutting too many row groups since they are not sorted across them.

Testing this in dev.

<img width="1229" alt="image" src="https://github.com/grafana/phlare/assets/1053421/0f2c1e3f-3502-4729-aa80-0565d246cae1">
