### PR TITLE
Sort Profiles across row groups when flushing blocks

### DIFF
--- a/pkg/parquet/row_reader.go
+++ b/pkg/parquet/row_reader.go
@@ -1,7 +1,6 @@
 package parquet
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/grafana/phlare/pkg/iter"
@@ -75,8 +74,6 @@ func (s *MergeRowReader) ReadRows(rows []parquet.Row) (int, error) {
 			return n, io.EOF
 		}
 		rows[n] = s.tree.Winner().At()
-		fmt.Println("MergeRowReader rows", rows[n][1].Int32(), " ", rows[n][11].Int64())
-
 		n++
 	}
 	return n, nil
@@ -101,7 +98,6 @@ func NewBufferedRowReaderIterator(reader parquet.RowReader, bufferSize int) *Buf
 func (r *BufferedRowReaderIterator) Next() bool {
 	if len(r.buff) > 1 {
 		r.buff = r.buff[1:]
-		// fmt.Println("Next", r.buff[0][1].Int32(), " ", r.buff[0][11].Int64())
 		return true
 	}
 
@@ -119,7 +115,6 @@ func (r *BufferedRowReaderIterator) Next() bool {
 	}
 
 	r.buff = r.buff[:n]
-	// fmt.Println("Next after read", r.buff[0][1].Int32(), " ", r.buff[0][11].Int64())
 	return true
 }
 
@@ -127,8 +122,6 @@ func (r *BufferedRowReaderIterator) At() parquet.Row {
 	if len(r.buff) == 0 {
 		return parquet.Row{}
 	}
-	// fmt.Println("At", r.buff[0][1].Int32(), " ", r.buff[0][11].Int64())
-
 	return r.buff[0]
 }
 

--- a/pkg/parquet/row_reader.go
+++ b/pkg/parquet/row_reader.go
@@ -107,11 +107,11 @@ func (r *BufferedRowReaderIterator) Next() bool {
 	}
 	r.buff = r.buff[:r.bufferSize]
 	n, err := r.reader.ReadRows(r.buff)
-	if n == 0 {
-		return false
-	}
 	if err != nil && err != io.EOF {
 		r.err = err
+		return false
+	}
+	if n == 0 {
 		return false
 	}
 

--- a/pkg/parquet/row_reader.go
+++ b/pkg/parquet/row_reader.go
@@ -1,0 +1,153 @@
+package parquet
+
+import (
+	"io"
+
+	"github.com/grafana/phlare/pkg/iter"
+	"github.com/grafana/phlare/pkg/util/loser"
+	"github.com/segmentio/parquet-go"
+)
+
+const (
+	defaultRowBufferSize = 1024
+)
+
+var (
+	_ parquet.RowReader          = (*emptyRowReader)(nil)
+	_ parquet.RowReader          = (*ErrRowReader)(nil)
+	_ parquet.RowReader          = (*MergeRowReader)(nil)
+	_ iter.Iterator[parquet.Row] = (*BufferedRowReaderIterator)(nil)
+
+	EmptyRowReader = &emptyRowReader{}
+)
+
+type emptyRowReader struct{}
+
+func (e *emptyRowReader) ReadRows(rows []parquet.Row) (int, error) { return 0, io.EOF }
+
+type ErrRowReader struct{ err error }
+
+func NewErrRowReader(err error) *ErrRowReader { return &ErrRowReader{err: err} }
+
+func (e ErrRowReader) ReadRows(rows []parquet.Row) (int, error) { return 0, e.err }
+
+type MergeRowReader struct {
+	tree *loser.Tree[parquet.Row, iter.Iterator[parquet.Row]]
+}
+
+// NewMergeRowReader returns a RowReader that k-way merges the given readers using the less function.
+// Each reader must be sorted according to the less function already.
+func NewMergeRowReader(readers []parquet.RowReader, maxValue parquet.Row, less func(parquet.Row, parquet.Row) bool) parquet.RowReader {
+	if len(readers) == 0 {
+		return EmptyRowReader
+	}
+	if len(readers) == 1 {
+		return readers[0]
+	}
+	its := make([]iter.Iterator[parquet.Row], len(readers))
+	for i, r := range readers {
+		its[i] = NewBufferedRowReaderIterator(r, defaultRowBufferSize)
+	}
+
+	return &MergeRowReader{
+		tree: loser.New(
+			its,
+			maxValue,
+			func(it iter.Iterator[parquet.Row]) parquet.Row { return it.At() },
+			less,
+			func(it iter.Iterator[parquet.Row]) { it.Close() },
+		),
+	}
+}
+
+func (s *MergeRowReader) ReadRows(rows []parquet.Row) (int, error) {
+	var n int
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	for {
+		if n == len(rows) {
+			break
+		}
+		if !s.tree.Next() {
+			return n, io.EOF
+		}
+		rows[n] = s.tree.Winner().At()
+		n++
+	}
+	return n, nil
+}
+
+type BufferedRowReaderIterator struct {
+	reader     parquet.RowReader
+	buff       []parquet.Row
+	bufferSize int
+	err        error
+}
+
+// NewBufferedRowReaderIterator returns a new `iter.Iterator[parquet.Row]` from a RowReader.
+// The iterator will buffer `bufferSize` rows from the reader.
+func NewBufferedRowReaderIterator(reader parquet.RowReader, bufferSize int) *BufferedRowReaderIterator {
+	return &BufferedRowReaderIterator{
+		reader:     reader,
+		bufferSize: bufferSize,
+	}
+}
+
+func (r *BufferedRowReaderIterator) Next() bool {
+	if len(r.buff) > 1 {
+		r.buff = r.buff[1:]
+		return true
+	}
+	if cap(r.buff) < r.bufferSize {
+		r.buff = make([]parquet.Row, r.bufferSize)
+	}
+	r.buff = r.buff[:r.bufferSize]
+	n, err := r.reader.ReadRows(r.buff)
+	if n == 0 {
+		return false
+	}
+	if err != nil && err != io.EOF {
+		r.err = err
+		return false
+	}
+	r.buff = r.buff[:n]
+	return true
+}
+
+func (r *BufferedRowReaderIterator) At() parquet.Row {
+	if len(r.buff) == 0 {
+		return parquet.Row{}
+	}
+	return r.buff[0]
+}
+
+func (r *BufferedRowReaderIterator) Err() error {
+	return r.err
+}
+
+func (r *BufferedRowReaderIterator) Close() error {
+	return r.err
+}
+
+func ReadAll(r parquet.RowReader) ([]parquet.Row, error) {
+	return ReadAllWithBufferSize(r, defaultRowBufferSize)
+}
+
+func ReadAllWithBufferSize(r parquet.RowReader, bufferSize int) ([]parquet.Row, error) {
+	var rows []parquet.Row
+	batch := make([]parquet.Row, bufferSize)
+	for {
+		n, err := r.ReadRows(batch)
+		if err != nil && err != io.EOF {
+			return rows, err
+		}
+		if n != 0 {
+			rows = append(rows, batch[:n]...)
+		}
+		if n == 0 || err == io.EOF {
+			break
+		}
+	}
+	return rows, nil
+}

--- a/pkg/parquet/row_reader.go
+++ b/pkg/parquet/row_reader.go
@@ -3,9 +3,10 @@ package parquet
 import (
 	"io"
 
+	"github.com/segmentio/parquet-go"
+
 	"github.com/grafana/phlare/pkg/iter"
 	"github.com/grafana/phlare/pkg/util/loser"
-	"github.com/segmentio/parquet-go"
 )
 
 const (

--- a/pkg/parquet/row_reader_test.go
+++ b/pkg/parquet/row_reader_test.go
@@ -1,0 +1,143 @@
+package parquet
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/segmentio/parquet-go"
+	"github.com/stretchr/testify/require"
+)
+
+var _ parquet.RowReader = (*BatchReader)(nil)
+
+type BatchReader struct {
+	batches [][]parquet.Row
+}
+
+func NewBatchReader(batches [][]parquet.Row) *BatchReader {
+	return &BatchReader{batches: batches}
+}
+
+func (br *BatchReader) ReadRows(rows []parquet.Row) (int, error) {
+	if len(br.batches) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(rows, br.batches[0])
+	if n < len(br.batches[0]) {
+		br.batches[0] = br.batches[0][n:]
+		return n, nil
+	}
+	br.batches = br.batches[1:]
+	return n, nil
+}
+
+func TestBufferedRowReaderIterator(t *testing.T) {
+	testBatchSize := func(n int) func(t *testing.T) {
+		return func(t *testing.T) {
+			reader := NewBufferedRowReaderIterator(
+				NewBatchReader(
+					[][]parquet.Row{
+						{{parquet.Int32Value(1)}},
+						{{parquet.Int32Value(2)}, {parquet.Int32Value(3)}},
+						{{parquet.Int32Value(4)}},
+					}),
+				n)
+			require.True(t, reader.Next())
+			require.Equal(t, parquet.Int32Value(1), reader.At()[0])
+			require.True(t, reader.Next())
+			require.Equal(t, parquet.Int32Value(2), reader.At()[0])
+			require.True(t, reader.Next())
+			require.Equal(t, parquet.Int32Value(3), reader.At()[0])
+			require.True(t, reader.Next())
+			require.Equal(t, parquet.Int32Value(4), reader.At()[0])
+			require.False(t, reader.Next())
+		}
+	}
+	t.Run("batch of 1", testBatchSize(1))
+	t.Run("bigger batch", testBatchSize(100))
+	t.Run("equal batch", testBatchSize(2))
+}
+
+func TestNewMergeRowReader(t *testing.T) {
+	for _, batchSize := range []int{1, 2, 3, 4, 5, 6} {
+		bufferSize := batchSize
+		t.Run(fmt.Sprintf("%d", bufferSize), func(t *testing.T) {
+			for _, tc := range []struct {
+				name     string
+				readers  []parquet.RowReader
+				expected []parquet.Row
+			}{
+				{
+					"merge 1 readers",
+					[]parquet.RowReader{
+						NewBatchReader([][]parquet.Row{
+							{{parquet.Int32Value(1)}},
+							{{parquet.Int32Value(3)}},
+							{{parquet.Int32Value(5)}},
+						}),
+					},
+					[]parquet.Row{
+						{parquet.Int32Value(1)},
+						{parquet.Int32Value(3)},
+						{parquet.Int32Value(5)},
+					},
+				},
+				{
+					"merge 2 readers",
+					[]parquet.RowReader{
+						NewBatchReader([][]parquet.Row{
+							{{parquet.Int32Value(1)}},
+							{{parquet.Int32Value(3)}},
+							{{parquet.Int32Value(5)}},
+						}),
+						NewBatchReader([][]parquet.Row{
+							{{parquet.Int32Value(2)}},
+							{{parquet.Int32Value(4)}},
+							{{parquet.Int32Value(6)}},
+						}),
+					},
+					[]parquet.Row{
+						{parquet.Int32Value(1)},
+						{parquet.Int32Value(2)},
+						{parquet.Int32Value(3)},
+						{parquet.Int32Value(4)},
+						{parquet.Int32Value(5)},
+						{parquet.Int32Value(6)},
+					},
+				},
+				{
+					"merge 3 readers 1 value",
+					[]parquet.RowReader{
+						NewBatchReader([][]parquet.Row{
+							{{parquet.Int32Value(1)}},
+						}),
+						NewBatchReader([][]parquet.Row{
+							{{parquet.Int32Value(2)}},
+						}),
+						NewBatchReader([][]parquet.Row{
+							{{parquet.Int32Value(3)}},
+						}),
+					},
+					[]parquet.Row{
+						{parquet.Int32Value(1)},
+						{parquet.Int32Value(2)},
+						{parquet.Int32Value(3)},
+					},
+				},
+			} {
+				tc := tc
+				t.Run(tc.name, func(t *testing.T) {
+					reader := NewMergeRowReader(tc.readers, parquet.Row{parquet.Int32Value(math.MaxInt32)}, func(r1, r2 parquet.Row) bool {
+						return r1[0].Int32() < r2[0].Int32()
+					})
+
+					actual, err := ReadAllWithBufferSize(reader, bufferSize)
+					require.NoError(t, err)
+					require.Equal(t, tc.expected, actual)
+				})
+			}
+		})
+	}
+}

--- a/pkg/parquet/row_writer.go
+++ b/pkg/parquet/row_writer.go
@@ -1,0 +1,71 @@
+package parquet
+
+import (
+	"io"
+
+	"github.com/segmentio/parquet-go"
+)
+
+type RowGroupWriter interface {
+	parquet.RowWriter
+	Flush() error
+}
+
+// CopyAsRowGroups copies row groups to dst from src and flush a rowgroup per rowGroupNumCount read.
+// It returns the total number of rows copied and the number of row groups written.
+// Flush is called to create a new row group.
+func CopyAsRowGroups(dst RowGroupWriter, src parquet.RowReader, rowGroupNumCount int) (total uint64, rowGroupCount uint64, err error) {
+	if rowGroupNumCount <= 0 {
+		panic("rowGroupNumCount must be positive")
+	}
+	bufferSize := defaultRowBufferSize
+	// We clamp the buffer to the rowGroupNumCount to avoid allocating a buffer that is too large.
+	if rowGroupNumCount < bufferSize {
+		bufferSize = rowGroupNumCount
+	}
+	var (
+		buffer            = make([]parquet.Row, bufferSize)
+		currentGroupCount int
+	)
+
+	for {
+		n, err := src.ReadRows(buffer[:bufferSize])
+		if err != nil && err != io.EOF {
+			return 0, 0, err
+		}
+		if n == 0 {
+			break
+		}
+		buffer := buffer[:n]
+		if currentGroupCount+n >= rowGroupNumCount {
+			batchSize := rowGroupNumCount - currentGroupCount
+			written, err := dst.WriteRows(buffer[:batchSize])
+			if err != nil {
+				return 0, 0, err
+			}
+			buffer = buffer[batchSize:]
+			total += uint64(written)
+			if err := dst.Flush(); err != nil {
+				return 0, 0, err
+			}
+			rowGroupCount++
+			currentGroupCount = 0
+		}
+		if len(buffer) == 0 {
+			continue
+		}
+		written, err := dst.WriteRows(buffer)
+		if err != nil {
+			return 0, 0, err
+		}
+		total += uint64(written)
+		currentGroupCount += written
+	}
+	if currentGroupCount > 0 {
+		if err := dst.Flush(); err != nil {
+			return 0, 0, err
+		}
+		rowGroupCount++
+	}
+	return
+}

--- a/pkg/parquet/row_writer_test.go
+++ b/pkg/parquet/row_writer_test.go
@@ -1,0 +1,149 @@
+package parquet
+
+import (
+	"testing"
+
+	"github.com/segmentio/parquet-go"
+	"github.com/stretchr/testify/require"
+)
+
+var _ RowGroupWriter = (*TestRowGroupWriter)(nil)
+
+type TestRowGroupWriter struct {
+	RowGroups       [][]parquet.Row
+	currentRowGroup int
+}
+
+func (r *TestRowGroupWriter) WriteRows(rows []parquet.Row) (int, error) {
+	if len(r.RowGroups) <= r.currentRowGroup {
+		r.RowGroups = append(r.RowGroups, []parquet.Row{})
+	}
+	r.RowGroups[r.currentRowGroup] = append(r.RowGroups[r.currentRowGroup], rows...)
+	return len(rows), nil
+}
+
+func (r *TestRowGroupWriter) Flush() error {
+	r.currentRowGroup++
+	return nil
+}
+
+func TestCopyAsRowGroups(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		rowGroupNumCount int
+		reader           parquet.RowReader
+		expected         [][]parquet.Row
+	}{
+		{
+			"empty",
+			1,
+			EmptyRowReader,
+			nil,
+		},
+		{
+			"one row",
+			1,
+			NewBatchReader([][]parquet.Row{
+				{{parquet.Int32Value(1)}},
+			}),
+			[][]parquet.Row{
+				{{parquet.Int32Value(1)}},
+			},
+		},
+		{
+			"one row per group",
+			1,
+			NewBatchReader([][]parquet.Row{
+				{{parquet.Int32Value(1)}},
+				{{parquet.Int32Value(2)}, {parquet.Int32Value(3)}},
+				{{parquet.Int32Value(4)}},
+			}),
+			[][]parquet.Row{
+				{{parquet.Int32Value(1)}},
+				{{parquet.Int32Value(2)}},
+				{{parquet.Int32Value(3)}},
+				{{parquet.Int32Value(4)}},
+			},
+		},
+		{
+			"two row per group",
+			2,
+			NewBatchReader([][]parquet.Row{
+				{{parquet.Int32Value(1)}},
+				{{parquet.Int32Value(2)}, {parquet.Int32Value(3)}},
+				{{parquet.Int32Value(4)}},
+			}),
+			[][]parquet.Row{
+				{{parquet.Int32Value(1)}, {parquet.Int32Value(2)}},
+				{{parquet.Int32Value(3)}, {parquet.Int32Value(4)}},
+			},
+		},
+		{
+			"two row per group not full",
+			2,
+			NewBatchReader([][]parquet.Row{
+				{{parquet.Int32Value(1)}},
+				{{parquet.Int32Value(2)}, {parquet.Int32Value(3)}, {parquet.Int32Value(4)}, {parquet.Int32Value(5)}},
+			}),
+			[][]parquet.Row{
+				{{parquet.Int32Value(1)}, {parquet.Int32Value(2)}},
+				{{parquet.Int32Value(3)}, {parquet.Int32Value(4)}},
+				{{parquet.Int32Value(5)}},
+			},
+		},
+		{
+			"more in the group than the reader can read",
+			10000,
+			NewBatchReader([][]parquet.Row{
+				{{parquet.Int32Value(1)}},
+				{{parquet.Int32Value(2)}, {parquet.Int32Value(3)}, {parquet.Int32Value(4)}, {parquet.Int32Value(5)}},
+			}),
+			[][]parquet.Row{
+				{
+					{parquet.Int32Value(1)},
+					{parquet.Int32Value(2)},
+					{parquet.Int32Value(3)},
+					{parquet.Int32Value(4)},
+					{parquet.Int32Value(5)},
+				},
+			},
+		},
+		{
+			"more in the reader",
+			10000,
+			NewBatchReader([][]parquet.Row{
+				generateRows(5000),
+				generateRows(3000),
+			}),
+			[][]parquet.Row{
+				append(generateRows(5000), generateRows(3000)...),
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			writer := &TestRowGroupWriter{}
+			total, rowGroupCount, err := CopyAsRowGroups(writer, tc.reader, tc.rowGroupNumCount)
+			require.NoError(t, err)
+			require.Equal(t, uint64(countRows(tc.expected)), total)
+			require.Equal(t, uint64(len(tc.expected)), rowGroupCount)
+			require.Equal(t, tc.expected, writer.RowGroups)
+		})
+	}
+}
+
+func countRows(rows [][]parquet.Row) int {
+	count := 0
+	for _, r := range rows {
+		count += len(r)
+	}
+	return count
+}
+
+func generateRows(count int) []parquet.Row {
+	rows := make([]parquet.Row, count)
+	for i := 0; i < count; i++ {
+		rows[i] = parquet.Row{parquet.Int32Value(int32(i))}
+	}
+	return rows
+}

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -364,8 +364,11 @@ func (s *profileStore) writeRowGroups(path string, rowGroups []parquet.RowGroup)
 		return 0, 0, err
 	}
 	defer runutil.CloseWithErrCapture(&err, fileCloser, "closing parquet file")
-
-	n, numRowGroups, err = phlareparquet.CopyAsRowGroups(s.writer, schemav1.NewMergeProfilesRowReader(rowGroups), s.cfg.MaxBufferRowCount)
+	readers := make([]parquet.RowReader, len(rowGroups))
+	for i, rg := range rowGroups {
+		readers[i] = rg.Rows()
+	}
+	n, numRowGroups, err = phlareparquet.CopyAsRowGroups(s.writer, schemav1.NewMergeProfilesRowReader(readers), s.cfg.MaxBufferRowCount)
 
 	if err := s.writer.Close(); err != nil {
 		return 0, 0, err

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -17,12 +18,14 @@ import (
 	"github.com/segmentio/parquet-go"
 	"go.uber.org/atomic"
 
+	"github.com/grafana/phlare/pkg/iter"
 	phlaremodel "github.com/grafana/phlare/pkg/model"
 	phlarecontext "github.com/grafana/phlare/pkg/phlare/context"
 	"github.com/grafana/phlare/pkg/phlaredb/block"
 	"github.com/grafana/phlare/pkg/phlaredb/query"
 	schemav1 "github.com/grafana/phlare/pkg/phlaredb/schemas/v1"
 	"github.com/grafana/phlare/pkg/util/build"
+	"github.com/grafana/phlare/pkg/util/loser"
 )
 
 type profileStore struct {
@@ -357,6 +360,223 @@ func (s *profileStore) loadProfilesToFlush(count int) uint64 {
 	return size
 }
 
+type RowGroupWriter interface {
+	parquet.RowWriter
+	Flush() error
+}
+
+// CopyRowGroups copies row groups to dst from src and flush a rowgroup per rowGroupNumCount read.
+func CopyRowGroups(dst RowGroupWriter, src parquet.RowReader, rowGroupNumCount int) (total uint64, rowGroupCount uint64, err error) {
+	if rowGroupNumCount <= 0 {
+		panic("rowGroupNumCount must be positive")
+	}
+	bufferSize := 1024
+	if rowGroupNumCount < bufferSize {
+		bufferSize = rowGroupNumCount
+	}
+	var (
+		buffer            = make([]parquet.Row, bufferSize)
+		currentGroupCount int
+	)
+
+	for {
+		n, err := src.ReadRows(buffer[:bufferSize])
+		if err != nil && err != io.EOF {
+			return 0, 0, err
+		}
+		if n == 0 {
+			break
+		}
+		buffer := buffer[:n]
+		if currentGroupCount+n >= rowGroupNumCount {
+			batchSize := rowGroupNumCount - currentGroupCount
+			written, err := dst.WriteRows(buffer[:batchSize])
+			if err != nil {
+				return 0, 0, err
+			}
+			buffer = buffer[batchSize:]
+			total += uint64(written)
+			if err := dst.Flush(); err != nil {
+				return 0, 0, err
+			}
+			rowGroupCount++
+			currentGroupCount = 0
+		}
+		if len(buffer) == 0 {
+			continue
+		}
+		written, err := dst.WriteRows(buffer)
+		if err != nil {
+			return 0, 0, err
+		}
+		total += uint64(written)
+		currentGroupCount += written
+	}
+	if currentGroupCount > 0 {
+		if err := dst.Flush(); err != nil {
+			return 0, 0, err
+		}
+		rowGroupCount++
+	}
+	return
+}
+
+type EmptyRowReader struct{}
+
+func (e *EmptyRowReader) ReadRows(rows []parquet.Row) (int, error) { return 0, io.EOF }
+
+type ErrRowReader struct{ err error }
+
+func NewErrRowReader(err error) *ErrRowReader { return &ErrRowReader{err: err} }
+
+func (e ErrRowReader) ReadRows(rows []parquet.Row) (int, error) { return 0, e.err }
+
+func NewSortedProfiles(rowGroups []parquet.RowGroup) parquet.RowReader {
+	if len(rowGroups) == 0 {
+		return &EmptyRowReader{}
+	}
+
+	readers := make([]parquet.RowReader, len(rowGroups))
+	for i, rg := range rowGroups {
+		readers[i] = rg.Rows()
+	}
+
+	schema := (&schemav1.ProfilePersister{}).Schema()
+	seriesCol, ok := schema.Lookup("SeriesIndex")
+	if !ok {
+		return NewErrRowReader(fmt.Errorf("SeriesIndex index column not found"))
+	}
+	timeCol, ok := schema.Lookup("TimeNanos")
+	if !ok {
+		return NewErrRowReader(fmt.Errorf("TimeNanos column not found"))
+	}
+	var maxVal parquet.Row
+	maxVal = schemav1.DeconstructMemoryProfile(schemav1.InMemoryProfile{
+		SeriesIndex: math.MaxUint32,
+		TimeNanos:   math.MaxInt64,
+	}, maxVal)
+	return NewSortedRowReader(readers, maxVal, func(r1, r2 parquet.Row) bool {
+		var (
+			sv1, tv1 parquet.Value
+			sv2, tv2 parquet.Value
+		)
+		r1.Range(func(columnIndex int, columnValues []parquet.Value) bool {
+			if columnIndex == seriesCol.ColumnIndex {
+				sv1 = columnValues[0]
+			}
+			if columnIndex == timeCol.ColumnIndex {
+				tv1 = columnValues[0]
+			}
+			if columnIndex >= timeCol.ColumnIndex && columnIndex >= seriesCol.ColumnIndex {
+				return false
+			}
+			return true
+		})
+		r2.Range(func(columnIndex int, columnValues []parquet.Value) bool {
+			if columnIndex == seriesCol.ColumnIndex {
+				sv2 = columnValues[0]
+			}
+			if columnIndex == timeCol.ColumnIndex {
+				tv2 = columnValues[0]
+			}
+			if columnIndex >= timeCol.ColumnIndex && columnIndex >= seriesCol.ColumnIndex {
+				return false
+			}
+			return true
+		})
+		if sv1.Int32() < sv2.Int32() {
+			return true
+		}
+		if sv1.Int32() > sv2.Int32() {
+			return false
+		}
+		return tv1.Int64() < tv2.Int64()
+	})
+}
+
+type SortedRowReader struct {
+	tree *loser.Tree[parquet.Row, iter.Iterator[parquet.Row]]
+}
+
+func (s *SortedRowReader) ReadRows(rows []parquet.Row) (int, error) {
+	var n int
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	for {
+		if n == len(rows) {
+			break
+		}
+		if !s.tree.Next() {
+			return n, io.EOF
+		}
+		rows[n] = s.tree.Winner().At()
+		n++
+	}
+	return n, nil
+}
+
+func NewSortedRowReader(readers []parquet.RowReader, maxValue parquet.Row, less func(parquet.Row, parquet.Row) bool) *SortedRowReader {
+	its := make([]iter.Iterator[parquet.Row], len(readers))
+	for i, r := range readers {
+		its[i] = NewBufferedRowReaderIterator(r, 1024)
+	}
+
+	return &SortedRowReader{
+		tree: loser.New(its, maxValue, func(it iter.Iterator[parquet.Row]) parquet.Row { return it.At() }, less, func(it iter.Iterator[parquet.Row]) { it.Close() }),
+	}
+}
+
+type BufferedRowReaderIterator struct {
+	reader     parquet.RowReader
+	buff       []parquet.Row
+	bufferSize int
+	err        error
+}
+
+func NewBufferedRowReaderIterator(reader parquet.RowReader, bufferSize int) *BufferedRowReaderIterator {
+	return &BufferedRowReaderIterator{
+		reader:     reader,
+		bufferSize: bufferSize,
+	}
+}
+
+func (r *BufferedRowReaderIterator) Next() bool {
+	if len(r.buff) > 1 {
+		r.buff = r.buff[1:]
+		return true
+	}
+	if cap(r.buff) < r.bufferSize {
+		r.buff = make([]parquet.Row, r.bufferSize)
+	}
+	r.buff = r.buff[:r.bufferSize]
+	n, err := r.reader.ReadRows(r.buff)
+	if n == 0 {
+		return false
+	}
+	if err != nil && err != io.EOF {
+		r.err = err
+		return false
+	}
+	r.buff = r.buff[:n]
+	return true
+}
+
+func (r *BufferedRowReaderIterator) At() parquet.Row {
+	if len(r.buff) == 0 {
+		return parquet.Row{}
+	}
+	return r.buff[0]
+}
+
+func (r *BufferedRowReaderIterator) Err() error {
+	return r.err
+}
+
+func (r *BufferedRowReaderIterator) Close() error {
+	return r.err
+}
+
 func (s *profileStore) writeRowGroups(path string, rowGroups []parquet.RowGroup) (n uint64, numRowGroups uint64, err error) {
 	fileCloser, err := s.prepareFile(path)
 	if err != nil {
@@ -364,21 +584,7 @@ func (s *profileStore) writeRowGroups(path string, rowGroups []parquet.RowGroup)
 	}
 	defer runutil.CloseWithErrCapture(&err, fileCloser, "closing parquet file")
 
-	for rgN, rg := range rowGroups {
-		level.Debug(s.logger).Log("msg", "writing row group", "path", path, "row_group_number", rgN, "rows", rg.NumRows())
-
-		nInt64, err := s.writer.ReadRowsFrom(rg.Rows())
-		if err != nil {
-			return 0, 0, err
-		}
-
-		n += uint64(nInt64)
-		numRowGroups += 1
-
-		if err := s.writer.Flush(); err != nil {
-			return 0, 0, err
-		}
-	}
+	n, numRowGroups, err = CopyRowGroups(s.writer, NewSortedProfiles(rowGroups), s.cfg.MaxBufferRowCount)
 
 	if err := s.writer.Close(); err != nil {
 		return 0, 0, err

--- a/pkg/phlaredb/profile_store_test.go
+++ b/pkg/phlaredb/profile_store_test.go
@@ -169,27 +169,27 @@ func TestProfileStore_RowGroupSplitting(t *testing.T) {
 		expectedNumRGs  uint64
 		values          func(int) *testProfile
 	}{
-		{
-			name:            "single row group",
-			cfg:             defaultParquetConfig,
-			expectedNumRGs:  1,
-			expectedNumRows: 100,
-			values:          sameProfileStream,
-		},
-		{
-			name:            "multiple row groups because of maximum size",
-			cfg:             &ParquetConfig{MaxRowGroupBytes: 1828, MaxBufferRowCount: 100000},
-			expectedNumRGs:  10,
-			expectedNumRows: 100,
-			values:          sameProfileStream,
-		},
-		{
-			name:            "a stream ending after half of the samples and a new one starting",
-			cfg:             &ParquetConfig{MaxRowGroupBytes: 1828, MaxBufferRowCount: 100000},
-			expectedNumRGs:  10,
-			expectedNumRows: 100,
-			values:          profileStreamEndingAndStarting(50),
-		},
+		// {
+		// 	name:            "single row group",
+		// 	cfg:             defaultParquetConfig,
+		// 	expectedNumRGs:  1,
+		// 	expectedNumRows: 100,
+		// 	values:          sameProfileStream,
+		// },
+		// {
+		// 	name:            "multiple row groups because of maximum size",
+		// 	cfg:             &ParquetConfig{MaxRowGroupBytes: 1828, MaxBufferRowCount: 100000},
+		// 	expectedNumRGs:  10,
+		// 	expectedNumRows: 100,
+		// 	values:          sameProfileStream,
+		// },
+		// {
+		// 	name:            "a stream ending after half of the samples and a new one starting",
+		// 	cfg:             &ParquetConfig{MaxRowGroupBytes: 1828, MaxBufferRowCount: 100000},
+		// 	expectedNumRGs:  10,
+		// 	expectedNumRows: 100,
+		// 	values:          profileStreamEndingAndStarting(50),
+		// },
 		{
 			name:            "multiple row groups because of maximum row num",
 			cfg:             &ParquetConfig{MaxRowGroupBytes: 128000, MaxBufferRowCount: 10},
@@ -197,13 +197,13 @@ func TestProfileStore_RowGroupSplitting(t *testing.T) {
 			expectedNumRows: 100,
 			values:          sameProfileStream,
 		},
-		{
-			name:            "a single sample per series",
-			cfg:             &ParquetConfig{MaxRowGroupBytes: 1828, MaxBufferRowCount: 100000},
-			expectedNumRGs:  10,
-			expectedNumRows: 100,
-			values:          nProfileStreams(100),
-		},
+		// {
+		// 	name:            "a single sample per series",
+		// 	cfg:             &ParquetConfig{MaxRowGroupBytes: 1828, MaxBufferRowCount: 100000},
+		// 	expectedNumRGs:  10,
+		// 	expectedNumRows: 100,
+		// 	values:          nProfileStreams(100),
+		// },
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			path := t.TempDir()

--- a/pkg/phlaredb/profile_store_test.go
+++ b/pkg/phlaredb/profile_store_test.go
@@ -169,13 +169,13 @@ func TestProfileStore_RowGroupSplitting(t *testing.T) {
 		expectedNumRGs  uint64
 		values          func(int) *testProfile
 	}{
-		// {
-		// 	name:            "single row group",
-		// 	cfg:             defaultParquetConfig,
-		// 	expectedNumRGs:  1,
-		// 	expectedNumRows: 100,
-		// 	values:          sameProfileStream,
-		// },
+		{
+			name:            "single row group",
+			cfg:             defaultParquetConfig,
+			expectedNumRGs:  1,
+			expectedNumRows: 100,
+			values:          sameProfileStream,
+		},
 		// {
 		// 	name:            "multiple row groups because of maximum size",
 		// 	cfg:             &ParquetConfig{MaxRowGroupBytes: 1828, MaxBufferRowCount: 100000},

--- a/pkg/phlaredb/profile_store_test.go
+++ b/pkg/phlaredb/profile_store_test.go
@@ -176,20 +176,13 @@ func TestProfileStore_RowGroupSplitting(t *testing.T) {
 			expectedNumRows: 100,
 			values:          sameProfileStream,
 		},
-		// {
-		// 	name:            "multiple row groups because of maximum size",
-		// 	cfg:             &ParquetConfig{MaxRowGroupBytes: 1828, MaxBufferRowCount: 100000},
-		// 	expectedNumRGs:  10,
-		// 	expectedNumRows: 100,
-		// 	values:          sameProfileStream,
-		// },
-		// {
-		// 	name:            "a stream ending after half of the samples and a new one starting",
-		// 	cfg:             &ParquetConfig{MaxRowGroupBytes: 1828, MaxBufferRowCount: 100000},
-		// 	expectedNumRGs:  10,
-		// 	expectedNumRows: 100,
-		// 	values:          profileStreamEndingAndStarting(50),
-		// },
+		{
+			name:            "a stream ending after half of the samples and a new one starting",
+			cfg:             &ParquetConfig{MaxRowGroupBytes: 128000, MaxBufferRowCount: 10},
+			expectedNumRGs:  10,
+			expectedNumRows: 100,
+			values:          profileStreamEndingAndStarting(50),
+		},
 		{
 			name:            "multiple row groups because of maximum row num",
 			cfg:             &ParquetConfig{MaxRowGroupBytes: 128000, MaxBufferRowCount: 10},
@@ -197,13 +190,13 @@ func TestProfileStore_RowGroupSplitting(t *testing.T) {
 			expectedNumRows: 100,
 			values:          sameProfileStream,
 		},
-		// {
-		// 	name:            "a single sample per series",
-		// 	cfg:             &ParquetConfig{MaxRowGroupBytes: 1828, MaxBufferRowCount: 100000},
-		// 	expectedNumRGs:  10,
-		// 	expectedNumRows: 100,
-		// 	values:          nProfileStreams(100),
-		// },
+		{
+			name:            "a single sample per series",
+			cfg:             &ParquetConfig{MaxRowGroupBytes: 128000, MaxBufferRowCount: 10},
+			expectedNumRGs:  10,
+			expectedNumRows: 100,
+			values:          nProfileStreams(100),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			path := t.TempDir()

--- a/pkg/phlaredb/schemas/v1/profiles.go
+++ b/pkg/phlaredb/schemas/v1/profiles.go
@@ -398,14 +398,9 @@ func deconstructMemoryProfile(imp InMemoryProfile, row parquet.Row) parquet.Row 
 	return row
 }
 
-func NewMergeProfilesRowReader(rowGroups []parquet.RowGroup) parquet.RowReader {
+func NewMergeProfilesRowReader(rowGroups []parquet.RowReader) parquet.RowReader {
 	if len(rowGroups) == 0 {
 		return phlareparquet.EmptyRowReader
-	}
-
-	readers := make([]parquet.RowReader, len(rowGroups))
-	for i, rg := range rowGroups {
-		readers[i] = rg.Rows()
 	}
 
 	seriesCol, ok := profilesSchema.Lookup("SeriesIndex")
@@ -417,7 +412,7 @@ func NewMergeProfilesRowReader(rowGroups []parquet.RowGroup) parquet.RowReader {
 		return phlareparquet.NewErrRowReader(fmt.Errorf("TimeNanos column not found"))
 	}
 
-	return phlareparquet.NewMergeRowReader(readers, maxProfileRow, func(r1, r2 parquet.Row) bool {
+	return phlareparquet.NewMergeRowReader(rowGroups, maxProfileRow, func(r1, r2 parquet.Row) bool {
 		var (
 			sv1, tv1 parquet.Value
 			sv2, tv2 parquet.Value

--- a/pkg/phlaredb/schemas/v1/profiles.go
+++ b/pkg/phlaredb/schemas/v1/profiles.go
@@ -441,9 +441,9 @@ func NewMergeProfilesRowReader(rowGroups []parquet.RowReader) parquet.RowReader 
 			}
 			return true
 		})
-		if sv1.Int32() == sv2.Int32() {
+		if sv1.Uint32() == sv2.Uint32() {
 			return tv1.Int64() < tv2.Int64()
 		}
-		return sv1.Int32() < sv2.Int32()
+		return sv1.Uint32() < sv2.Uint32()
 	})
 }

--- a/pkg/phlaredb/schemas/v1/profiles_test.go
+++ b/pkg/phlaredb/schemas/v1/profiles_test.go
@@ -158,11 +158,11 @@ func TestMergeProfiles(t *testing.T) {
 			{SeriesIndex: 2, TimeNanos: 5},
 			{SeriesIndex: 3, TimeNanos: 6},
 		}),
-		// NewInMemoryProfilesRowReader([]InMemoryProfile{
-		// 	{SeriesIndex: 1, TimeNanos: 7},
-		// 	{SeriesIndex: 2, TimeNanos: 8},
-		// 	{SeriesIndex: 3, TimeNanos: 9},
-		// }),
+		NewInMemoryProfilesRowReader([]InMemoryProfile{
+			{SeriesIndex: 1, TimeNanos: 7},
+			{SeriesIndex: 2, TimeNanos: 8},
+			{SeriesIndex: 3, TimeNanos: 9},
+		}),
 	})
 
 	actual, err := phlareparquet.ReadAll(reader)
@@ -170,13 +170,13 @@ func TestMergeProfiles(t *testing.T) {
 	compareProfileRows(t, generateProfileRow([]InMemoryProfile{
 		{SeriesIndex: 1, TimeNanos: 1},
 		{SeriesIndex: 1, TimeNanos: 4},
-		// {SeriesIndex: 1, TimeNanos: 7},
+		{SeriesIndex: 1, TimeNanos: 7},
 		{SeriesIndex: 2, TimeNanos: 2},
 		{SeriesIndex: 2, TimeNanos: 5},
-		// {SeriesIndex: 2, TimeNanos: 8},
+		{SeriesIndex: 2, TimeNanos: 8},
 		{SeriesIndex: 3, TimeNanos: 3},
 		{SeriesIndex: 3, TimeNanos: 6},
-		// {SeriesIndex: 3, TimeNanos: 9},
+		{SeriesIndex: 3, TimeNanos: 9},
 	}), actual)
 }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/phlare/issues/800

This k-way merge rowgroups on disk when we flush to a full block. Which means now a single series is expected to appear in only on rowgroup.

The only caveat if we only cut the final file rowgroup per rowcount but I think we can live with this since we never cut by size.