### PR TITLE
BlockQuerier.SelectMatchingProfiles: Fix condition that caused memory wastage

### DIFF
--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -1018,7 +1018,7 @@ func (b *singleBlockQuerier) SelectMatchingProfiles(ctx context.Context, params 
 		buf = res.Columns(buf, "SeriesIndex", "TimeNanos", "StacktracePartition")
 		seriesIndex := buf[0][0].Int64()
 		if seriesIndex != currSeriesIndex {
-			currSeriesIndex++
+			currSeriesIndex = seriesIndex
 			if len(currentSeriesSlice) > 0 {
 				iters = append(iters, iter.NewSliceIterator(currentSeriesSlice))
 			}


### PR DESCRIPTION
While investigating grafana/pyroscope#2038, I noticed we never had more than one slice element and as we allocate 100 elements, that added 100  times more memory pressure than necessary.

![Screenshot from 2023-06-28 10-21-51](https://github.com/grafana/phlare/assets/223048/5da10fef-d1ec-4c35-a4c7-1af478ac3d4f)
