### PR TITLE
fix(ebpf): compilation on windows and freebsd

### DIFF
--- a/ebpf/symtab/procmap.go
+++ b/ebpf/symtab/procmap.go
@@ -6,8 +6,6 @@ import (
 	"reflect"
 	"strconv"
 	"unsafe"
-
-	"golang.org/x/sys/unix"
 )
 
 // ProcMapPermissions contains permission settings read from `/proc/[pid]/maps`.
@@ -77,7 +75,18 @@ func parseDevice(s []byte) (uint64, error) {
 		return 0, err
 	}
 
-	return unix.Mkdev(uint32(major), uint32(minor)), nil
+	return mkdev(uint32(major), uint32(minor)), nil
+}
+
+// mkdev returns a Linux device number generated from the given major and minor
+// components.
+// this is a copy-paste from unix.Mkdev
+func mkdev(major, minor uint32) uint64 {
+	dev := (uint64(major) & 0x00000fff) << 8
+	dev |= (uint64(major) & 0xfffff000) << 32
+	dev |= (uint64(minor) & 0x000000ff) << 0
+	dev |= (uint64(minor) & 0xffffff00) << 12
+	return dev
 }
 
 // parseAddress converts a hex-string to a uintptr.

--- a/ebpf/symtab/stat_placeholder.go
+++ b/ebpf/symtab/stat_placeholder.go
@@ -1,4 +1,4 @@
-//go:build !unix
+//go:build !linux && !darwin
 
 package symtab
 
@@ -6,11 +6,11 @@ import (
 	"os"
 )
 
-type stat struct {
-	dev uint64
-	ino uint64
+type Stat struct {
+	Dev uint64
+	Ino uint64
 }
 
-func statFromFileInfo(file os.FileInfo) stat {
-	return stat{}
+func statFromFileInfo(file os.FileInfo) Stat {
+	return Stat{}
 }


### PR DESCRIPTION
- make Stat placeholder exported - same as in linux & darwin
- copy unix.mkdev function to be used on windows