### PR TITLE
Terminate stream in store gateway if no blocks found

### DIFF
--- a/pkg/querier/select_merge.go
+++ b/pkg/querier/select_merge.go
@@ -302,7 +302,7 @@ func selectMergeTree(ctx context.Context, responses []ResponseFromReplica[client
 		iter := iter
 		g.Go(util.RecoverPanic(func() error {
 			result, err := iter.Result()
-			if err != nil {
+			if err != nil || result == nil {
 				return err
 			}
 			switch result.Format {
@@ -363,7 +363,7 @@ func selectMergePprofProfile(ctx context.Context, ty *typesv1.ProfileType, respo
 		iter := iter
 		g.Go(util.RecoverPanic(func() error {
 			result, err := iter.Result()
-			if err != nil {
+			if err != nil || result == nil {
 				return err
 			}
 			p, err := profile.ParseUncompressed(result)
@@ -439,7 +439,7 @@ func selectMergeSeries(ctx context.Context, responses []ResponseFromReplica[clie
 		iter := iter
 		g.Go(util.RecoverPanic(func() error {
 			result, err := iter.Result()
-			if err != nil {
+			if err != nil || result == nil {
 				return err
 			}
 			s.Do(func() {


### PR DESCRIPTION
Currently, the query fails with a cryptic error when object store is queried before the first block is uploaded. The problem is that the querier expects the stream to the store-gateway is properly utilised and terminated regardless of anything, however store-gateways leave the stream intact, if no suitable blocks found. In ingesters, the stream is always utilised, even if there is no suitable data (subject of another issue, see grafana/pyroscope#2047). I decided to not change the logic but instead terminate the stream in the same way it is done when actual data is streamed.
