### PR TITLE
Adds iteration error support in the loser.Tree

### DIFF
--- a/pkg/iter/profiles.go
+++ b/pkg/iter/profiles.go
@@ -27,7 +27,7 @@ func lessProfile(p1, p2 Profile) bool {
 
 type MergeIterator[P Profile] struct {
 	tree        *loser.Tree[P, Iterator[P]]
-	errs        multierror.MultiError
+	closeErrs   multierror.MultiError
 	current     P
 	deduplicate bool
 }
@@ -59,7 +59,7 @@ func NewMergeIterator[P Profile](max P, deduplicate bool, iters ...Iterator[P]) 
 		},
 		func(s Iterator[P]) {
 			if err := s.Close(); err != nil {
-				iter.errs.Add(err)
+				iter.closeErrs.Add(err)
 			}
 		})
 	return iter
@@ -88,12 +88,12 @@ func (i *MergeIterator[P]) At() P {
 }
 
 func (i *MergeIterator[P]) Err() error {
-	return i.errs.Err()
+	return i.tree.Err()
 }
 
 func (i *MergeIterator[P]) Close() error {
 	i.tree.Close()
-	return i.Err()
+	return i.closeErrs.Err()
 }
 
 type TimeRangedIterator[T Timestamp] struct {

--- a/pkg/parquet/row_reader.go
+++ b/pkg/parquet/row_reader.go
@@ -72,6 +72,9 @@ func (s *MergeRowReader) ReadRows(rows []parquet.Row) (int, error) {
 		}
 		if !s.tree.Next() {
 			s.tree.Close()
+			if err := s.tree.Err(); err != nil {
+				return n, err
+			}
 			return n, io.EOF
 		}
 		rows[n] = s.tree.Winner().At()

--- a/pkg/querier/select_merge.go
+++ b/pkg/querier/select_merge.go
@@ -261,6 +261,9 @@ func skipDuplicates(ctx context.Context, its []MergeIterator) error {
 	}
 	span.LogFields(otlog.Int("duplicates", duplicates))
 	span.LogFields(otlog.Int("total", total))
+	if err := tree.Err(); err != nil {
+		errors.Add(err)
+	}
 
 	return errors.Err()
 }


### PR DESCRIPTION
This makes loser.Tree aware of Err() and stops as soon as an iterator return false from Next() with an Err() != nil.

Supersedes https://github.com/grafana/phlare/pull/828