### PR TITLE
Add terminationGracePeriodSeconds helm value

### DIFF
--- a/operations/phlare/helm/phlare/Chart.yaml
+++ b/operations/phlare/helm/phlare/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: phlare
 description: 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 type: application
-version: 0.5.3
+version: 0.5.4
 appVersion: 0.5.1
 dependencies:
   - name: minio

--- a/operations/phlare/helm/phlare/README.md
+++ b/operations/phlare/helm/phlare/README.md
@@ -1,6 +1,6 @@
 # phlare
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.1](https://img.shields.io/badge/AppVersion-0.5.1-informational?style=flat-square)
+![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.1](https://img.shields.io/badge/AppVersion-0.5.1-informational?style=flat-square)
 
 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 

--- a/operations/phlare/helm/phlare/rendered/micro-services.yaml
+++ b/operations/phlare/helm/phlare/rendered/micro-services.yaml
@@ -12,7 +12,7 @@ kind: ServiceAccount
 metadata:
   name: phlare-dev
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -358,7 +358,7 @@ kind: ConfigMap
 metadata:
   name: phlare-dev-overrides-config
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -374,7 +374,7 @@ kind: ConfigMap
 metadata:
   name: phlare-dev-config
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1039,7 +1039,7 @@ kind: ClusterRole
 metadata:
   name: default-phlare-dev
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1065,7 +1065,7 @@ kind: ClusterRoleBinding
 metadata:
   name: default-phlare-dev
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1153,7 +1153,7 @@ kind: Service
 metadata:
   name: phlare-dev-memberlist
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1179,7 +1179,7 @@ kind: Service
 metadata:
   name: phlare-dev-agent
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1203,7 +1203,7 @@ kind: Service
 metadata:
   name: phlare-dev-agent-headless
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1228,7 +1228,7 @@ kind: Service
 metadata:
   name: phlare-dev-distributor
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1252,7 +1252,7 @@ kind: Service
 metadata:
   name: phlare-dev-distributor-headless
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1277,7 +1277,7 @@ kind: Service
 metadata:
   name: phlare-dev-ingester
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1301,7 +1301,7 @@ kind: Service
 metadata:
   name: phlare-dev-ingester-headless
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1326,7 +1326,7 @@ kind: Service
 metadata:
   name: phlare-dev-querier
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1350,7 +1350,7 @@ kind: Service
 metadata:
   name: phlare-dev-querier-headless
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1375,7 +1375,7 @@ kind: Service
 metadata:
   name: phlare-dev-query-frontend
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1399,7 +1399,7 @@ kind: Service
 metadata:
   name: phlare-dev-query-frontend-headless
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1424,7 +1424,7 @@ kind: Service
 metadata:
   name: phlare-dev-query-scheduler
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1448,7 +1448,7 @@ kind: Service
 metadata:
   name: phlare-dev-query-scheduler-headless
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1473,7 +1473,7 @@ kind: Service
 metadata:
   name: phlare-dev-store-gateway
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1497,7 +1497,7 @@ kind: Service
 metadata:
   name: phlare-dev-store-gateway-headless
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1522,7 +1522,7 @@ kind: Deployment
 metadata:
   name: phlare-dev-agent
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1538,7 +1538,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1115b23a6b64ac92648f9e4bc43a571f388662fa077280488b506475ab51d69d
+        checksum/config: ae2c3325ef01f69fe19022a2f2aa9303fc57d603e39fcf438bfdea3b7720a696
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1611,7 +1611,7 @@ kind: Deployment
 metadata:
   name: phlare-dev-distributor
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1627,7 +1627,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1115b23a6b64ac92648f9e4bc43a571f388662fa077280488b506475ab51d69d
+        checksum/config: ae2c3325ef01f69fe19022a2f2aa9303fc57d603e39fcf438bfdea3b7720a696
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1699,7 +1699,7 @@ kind: Deployment
 metadata:
   name: phlare-dev-querier
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1715,7 +1715,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1115b23a6b64ac92648f9e4bc43a571f388662fa077280488b506475ab51d69d
+        checksum/config: ae2c3325ef01f69fe19022a2f2aa9303fc57d603e39fcf438bfdea3b7720a696
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1787,7 +1787,7 @@ kind: Deployment
 metadata:
   name: phlare-dev-query-frontend
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1803,7 +1803,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1115b23a6b64ac92648f9e4bc43a571f388662fa077280488b506475ab51d69d
+        checksum/config: ae2c3325ef01f69fe19022a2f2aa9303fc57d603e39fcf438bfdea3b7720a696
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1875,7 +1875,7 @@ kind: Deployment
 metadata:
   name: phlare-dev-query-scheduler
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -1891,7 +1891,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1115b23a6b64ac92648f9e4bc43a571f388662fa077280488b506475ab51d69d
+        checksum/config: ae2c3325ef01f69fe19022a2f2aa9303fc57d603e39fcf438bfdea3b7720a696
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2058,7 +2058,7 @@ kind: StatefulSet
 metadata:
   name: phlare-dev-ingester
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -2076,7 +2076,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1115b23a6b64ac92648f9e4bc43a571f388662fa077280488b506475ab51d69d
+        checksum/config: ae2c3325ef01f69fe19022a2f2aa9303fc57d603e39fcf438bfdea3b7720a696
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2149,7 +2149,7 @@ kind: StatefulSet
 metadata:
   name: phlare-dev-store-gateway
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -2167,7 +2167,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1115b23a6b64ac92648f9e4bc43a571f388662fa077280488b506475ab51d69d
+        checksum/config: ae2c3325ef01f69fe19022a2f2aa9303fc57d603e39fcf438bfdea3b7720a696
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2

--- a/operations/phlare/helm/phlare/rendered/micro-services.yaml
+++ b/operations/phlare/helm/phlare/rendered/micro-services.yaml
@@ -2132,6 +2132,7 @@ spec:
             requests:
               cpu: 1
               memory: 8Gi
+      terminationGracePeriodSeconds: 600
       volumes:
         - name: config
           configMap:

--- a/operations/phlare/helm/phlare/rendered/single-binary.yaml
+++ b/operations/phlare/helm/phlare/rendered/single-binary.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: phlare-dev
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: phlare-dev-overrides-config
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -33,7 +33,7 @@ kind: ConfigMap
 metadata:
   name: phlare-dev-config
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -690,7 +690,7 @@ kind: ClusterRole
 metadata:
   name: default-phlare-dev
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -716,7 +716,7 @@ kind: ClusterRoleBinding
 metadata:
   name: default-phlare-dev
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -736,7 +736,7 @@ kind: Service
 metadata:
   name: phlare-dev-memberlist
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -762,7 +762,7 @@ kind: Service
 metadata:
   name: phlare-dev
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -786,7 +786,7 @@ kind: Service
 metadata:
   name: phlare-dev-headless
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -811,7 +811,7 @@ kind: StatefulSet
 metadata:
   name: phlare-dev
   labels:
-    helm.sh/chart: phlare-0.5.3
+    helm.sh/chart: phlare-0.5.4
     app.kubernetes.io/name: phlare
     app.kubernetes.io/instance: phlare-dev
     app.kubernetes.io/version: "0.5.1"
@@ -829,7 +829,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a781867cc5e9bddb8a630ac1d270dfc07fd37bfa5f566f550419e23902522266
+        checksum/config: aff679be13b53f3f04cd7190b463fd9d399186bcfafb77397001857710088359
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2

--- a/operations/phlare/helm/phlare/templates/deployments-statefulsets.yaml
+++ b/operations/phlare/helm/phlare/templates/deployments-statefulsets.yaml
@@ -110,6 +110,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if $values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $values.terminationGracePeriodSeconds }}
+      {{- end }}
       volumes:
       {{- with $values.extraVolumes }}
       {{- toYaml . | nindent 8 }}

--- a/operations/phlare/helm/phlare/values-micro-services.yaml
+++ b/operations/phlare/helm/phlare/values-micro-services.yaml
@@ -52,6 +52,7 @@ phlare:
     ingester:
       kind: StatefulSet
       replicaCount: 3
+      terminationGracePeriodSeconds: 600
       resources:
         limits:
           memory: 16Gi

--- a/operations/phlare/jsonnet/values-micro-services.json
+++ b/operations/phlare/jsonnet/values-micro-services.json
@@ -41,7 +41,8 @@
             "cpu": 1,
             "memory": "8Gi"
           }
-        }
+        },
+        "terminationGracePeriodSeconds": 600
       },
       "querier": {
         "kind": "Deployment",


### PR DESCRIPTION
It's been reported multiple times that the unfinished block is lost at shutdown. One of the most common reasons in case of k8s deployment is the fact that ingesters may not be able to flush all the data before being terminated forcibly due to expiration of `terminationGracePeriodSeconds` (defaults to 30s).

The change makes the parameter configurable: now it is set to 10m by default for ingesters when deployed as micro services.

Related #688 