### PR TITLE
Measure page read duration

### DIFF
--- a/pkg/phlaredb/query/repeated.go
+++ b/pkg/phlaredb/query/repeated.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/grafana/dskit/multierror"
 	"github.com/opentracing/opentracing-go"
@@ -125,7 +126,9 @@ Outer:
 			it.rowFinished = true
 			it.skipping = false
 			var err error
+			pageReadStart := time.Now()
 			it.currentPage, err = it.currentPages.ReadPage()
+			pageReadDurationMs := time.Since(pageReadStart).Milliseconds()
 			if err != nil {
 				if err == io.EOF {
 					continue
@@ -138,6 +141,7 @@ Outer:
 				otlog.Int64("startRowGroupRowNum", it.startRowGroupRowNum),
 				otlog.Int64("startPageRowNum", it.startPageRowNum),
 				otlog.Int64("pageRowNum", it.currentPage.NumRows()),
+				otlog.Int64("duration_ms", pageReadDurationMs),
 			)
 			it.valueReader = it.currentPage.Values()
 		}


### PR DESCRIPTION
Despite the fact that we can derive the information based on the "distance" between events, is might be inaccurate:

<img width="1254" alt="image" src="https://github.com/grafana/phlare/assets/12090599/e1f8458c-bcb0-43af-9043-5c5f4b5460dd">
