### PR TITLE
Correctly saves the buffer capacity in BufferedRowReaderIterator

### DIFF
--- a/pkg/parquet/row_reader.go
+++ b/pkg/parquet/row_reader.go
@@ -84,7 +84,10 @@ func (s *MergeRowReader) ReadRows(rows []parquet.Row) (int, error) {
 }
 
 type BufferedRowReaderIterator struct {
-	reader     parquet.RowReader
+	reader       parquet.RowReader
+	bufferedRows []parquet.Row
+
+	// buff keep the original slice capacity to avoid allocations
 	buff       []parquet.Row
 	bufferSize int
 	err        error
@@ -100,16 +103,16 @@ func NewBufferedRowReaderIterator(reader parquet.RowReader, bufferSize int) *Buf
 }
 
 func (r *BufferedRowReaderIterator) Next() bool {
-	if len(r.buff) > 1 {
-		r.buff = r.buff[1:]
+	if len(r.bufferedRows) > 1 {
+		r.bufferedRows = r.bufferedRows[1:]
 		return true
 	}
 
 	if cap(r.buff) < r.bufferSize {
 		r.buff = make([]parquet.Row, r.bufferSize)
 	}
-	r.buff = r.buff[:r.bufferSize]
-	n, err := r.reader.ReadRows(r.buff)
+	r.bufferedRows = r.buff[:r.bufferSize]
+	n, err := r.reader.ReadRows(r.bufferedRows)
 	if err != nil && err != io.EOF {
 		r.err = err
 		return false
@@ -118,15 +121,15 @@ func (r *BufferedRowReaderIterator) Next() bool {
 		return false
 	}
 
-	r.buff = r.buff[:n]
+	r.bufferedRows = r.bufferedRows[:n]
 	return true
 }
 
 func (r *BufferedRowReaderIterator) At() parquet.Row {
-	if len(r.buff) == 0 {
+	if len(r.bufferedRows) == 0 {
 		return parquet.Row{}
 	}
-	return r.buff[0]
+	return r.bufferedRows[0]
 }
 
 func (r *BufferedRowReaderIterator) Err() error {

--- a/pkg/parquet/row_reader_test.go
+++ b/pkg/parquet/row_reader_test.go
@@ -141,3 +141,25 @@ func TestNewMergeRowReader(t *testing.T) {
 		})
 	}
 }
+
+type SomeRow struct {
+	Col1 int
+}
+
+func BenchmarkBufferedRowReader(b *testing.B) {
+	buff := parquet.NewGenericBuffer[SomeRow]()
+	for i := 0; i < 1000000; i++ {
+		_, err := buff.Write([]SomeRow{{Col1: (i)}})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	reader := NewBufferedRowReaderIterator(buff.Rows(), 100)
+	defer reader.Close()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for reader.Next() {
+			_ = reader.At()
+		}
+	}
+}


### PR DESCRIPTION
I was looking at compaction and trying to figure why it was slow.

```
❯ benchstat before.txt afte.txt
name                  old time/op    new time/op    delta
BufferedRowReader-16     709ns ±14%     306ns ± 3%   -56.88%  (p=0.008 n=5+5)

name                  old alloc/op   new alloc/op   delta
BufferedRowReader-16    2.72kB ± 0%    0.00kB       -100.00%  (p=0.008 n=5+5)

name                  old allocs/op  new allocs/op  delta
BufferedRowReader-16      1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
```

This is most likely makes flushing a block 50% faster and lighter.

PS: Not fully sure why we loose the slice capacity when slicing.