### PR TITLE
fix(ebpf): procmap parse test fix

### DIFF
--- a/ebpf/symtab/procmaps_test.go
+++ b/ebpf/symtab/procmaps_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/unix"
 )
 
 func TestProcMaps(t *testing.T) {
@@ -38,7 +37,7 @@ ffffffffff600000-ffffffffff601000 --xp 00000000 00:00 0                  [vsysca
 	if err != nil {
 		t.Fatal(err)
 	}
-	dev := unix.Mkdev(9, 0)
+	dev := mkdev(9, 0)
 	expected := []*ProcMap{
 		{
 			StartAddr: 0x5644e74ce000,


### PR DESCRIPTION
Use same packed dev structure in tests as in implementation

We use mkdev result as a cache key, it does not matter what the implementation is, it just should be the same