### PR TITLE
Optimise in-memory parquet reader

### DIFF
--- a/pkg/phlaredb/block_querier_test.go
+++ b/pkg/phlaredb/block_querier_test.go
@@ -38,7 +38,7 @@ func TestInMemoryReader(t *testing.T) {
 	require.Equal(t, uint64(rgCount*st.cfg.MaxBufferRowCount), numRows)
 	require.Equal(t, uint64(rgCount), numRg)
 	require.NoError(t, st.Close())
-	reader := inMemoryparquetReader[*schemav1.StoredString, *schemav1.StringPersister]{}
+	reader := inMemoryparquetReader[string, *schemav1.StringPersister]{}
 	fs, err := filesystem.NewBucket(path)
 	require.NoError(t, err)
 
@@ -46,9 +46,8 @@ func TestInMemoryReader(t *testing.T) {
 	it := reader.retrieveRows(context.Background(), iter.NewSliceIterator(lo.Times(int(numRows), func(i int) int64 { return int64(i) })))
 	var j int
 	for it.Next() {
-		require.Equal(t, it.At().Result.String, fmt.Sprintf("foobar %d", j))
+		require.Equal(t, it.At().Result, fmt.Sprintf("foobar %d", j))
 		require.Equal(t, it.At().RowNum, int64(j))
-		require.Equal(t, it.At().Result.ID, uint64(j))
 		j++
 	}
 
@@ -56,9 +55,8 @@ func TestInMemoryReader(t *testing.T) {
 	it = reader.retrieveRows(context.Background(), iter.NewSliceIterator(rows))
 	j = 0
 	for it.Next() {
-		require.Equal(t, it.At().Result.String, fmt.Sprintf("foobar %d", rows[j]))
+		require.Equal(t, it.At().Result, fmt.Sprintf("foobar %d", rows[j]))
 		require.Equal(t, it.At().RowNum, rows[j])
-		require.Equal(t, it.At().Result.ID, uint64(rows[j]))
 		j++
 	}
 }

--- a/pkg/phlaredb/head.go
+++ b/pkg/phlaredb/head.go
@@ -81,8 +81,8 @@ type Models interface {
 		*profilev1.Location | *schemav1.InMemoryLocation |
 		*profilev1.Function | *schemav1.InMemoryFunction |
 		*profilev1.Mapping | *schemav1.InMemoryMapping |
-		*schemav1.StoredString | string |
-		*schemav1.Stacktrace
+		*schemav1.Stacktrace |
+		string
 }
 
 func emptyRewriter() *rewriter {

--- a/pkg/phlaredb/sample_merge.go
+++ b/pkg/phlaredb/sample_merge.go
@@ -196,7 +196,7 @@ func (b *singleBlockQuerier) resolvePprofSymbols(ctx context.Context, profileSam
 	)
 	for strings.Next() {
 		s := strings.At()
-		names[idx] = s.Result.String
+		names[idx] = s.Result
 		stringsIds[s.RowNum] = idx
 		idx++
 	}
@@ -306,7 +306,7 @@ func (b *singleBlockQuerier) resolveSymbols(ctx context.Context, stacktracesByMa
 	)
 	for strings.Next() {
 		s := strings.At()
-		names[idx] = s.Result.String
+		names[idx] = s.Result
 		idSlice[idx] = []int64{s.RowNum}
 		idx++
 	}

--- a/pkg/phlaredb/schemas/v1/schema_test.go
+++ b/pkg/phlaredb/schemas/v1/schema_test.go
@@ -29,9 +29,6 @@ func TestSchemaMatch(t *testing.T) {
 
 	stacktracesStructSchema := parquet.SchemaOf(&storedStacktrace{})
 	require.Equal(t, strings.Replace(stacktracesStructSchema.String(), "message storedStacktrace", "message Stacktrace", 1), stacktracesSchema.String())
-
-	stringsStructSchema := parquet.SchemaOf(&StoredString{})
-	require.Equal(t, strings.Replace(stringsStructSchema.String(), "message StoredString", "message String", 1), stringsSchema.String())
 }
 
 func newStacktraces() []*Stacktrace {


### PR DESCRIPTION
The change makes in-memory parquet reader to not use the stored schema for reconstruction via `reflect`, and use hand-written reconstruction instead. 