### PR TITLE
chore(profilecli): accept timestamps for queries

### DIFF
--- a/cmd/profilecli/query.go
+++ b/cmd/profilecli/query.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -44,6 +45,27 @@ func parseTime(s string) (time.Time, error) {
 		return time.Now().Add(-d), nil
 	}
 
+	timestamp, terr := strconv.ParseInt(s, 10, 64)
+	if terr == nil {
+		/**
+		1689341454
+		1689341454046
+		1689341454046908
+		1689341454046908187
+		*/
+		switch len(s) {
+		case 10:
+			return time.Unix(timestamp, 0), nil
+		case 13:
+			return time.UnixMilli(timestamp), nil
+		case 16:
+			return time.UnixMicro(timestamp), nil
+		case 19:
+			return time.Unix(0, timestamp), nil
+		default:
+			return time.Time{}, fmt.Errorf("invalid timestamp length: %s", s)
+		}
+	}
 	// if not return first error
 	return time.Time{}, err
 


### PR DESCRIPTION
my brain is unable to remember `time.RFC3339` format :)